### PR TITLE
chore: make public shared types

### DIFF
--- a/.yarn/versions/11cca54f.yml
+++ b/.yarn/versions/11cca54f.yml
@@ -5,7 +5,7 @@ undecided:
   - "@thingco/graphviz-web"
   - "@thingco/react-component-library"
   - "@thingco/shared-types"
-  - "@thingco/unit-formatter"
+  - "@thingco/user-preferences"
   - "@thingco/user-preferences-store-native"
   - "@thingco/user-preferences-store-web"
   - "@thingco/shared-frontend-libs-playground"

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -3,9 +3,14 @@
 	"description": "Internal shared types for the shared-frontend-libs repo",
 	"version": "0.2.0",
 	"main": "index.js",
-	"module": "index.js",
 	"types": "index.d.ts",
-	"public": false,
+	"files": [
+		"**"
+	],
+	"public": true,
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com/"
+	},
 	"repository": "https://github.com/thingco/shared-frontend-libs",
 	"scripts": {
 		"docs": "yarn rimraf docs && yarn typedoc"

--- a/packages/unit-formatter/package.json
+++ b/packages/unit-formatter/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/unit-formatter",
 	"description": "React-based unit formatters",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [
@@ -20,7 +20,8 @@
 	"devDependencies": {
 		"@testing-library/jest-dom": "^5.14.1",
 		"@testing-library/react": "^11.2.7",
-		"@thingco/user-preferences": "0.5.0",
+		"@thingco/shared-types": "workspace:*",
+		"@thingco/user-preferences": "0.6.0",
 		"@types/jest": "^26.0.23",
 		"@types/react": "^17.0.11",
 		"@types/react-dom": "^17.0.8",
@@ -35,6 +36,7 @@
 		"typescript": "^4.3.4"
 	},
 	"peerDependencies": {
+		"@thingco/shared-types": "*",
 		"@thingco/user-preferences": "*",
 		"react": "*"
 	}

--- a/packages/unit-formatter/src/formatters.ts
+++ b/packages/unit-formatter/src/formatters.ts
@@ -1,11 +1,11 @@
-import {
+import { kmphToMph, metersToKilometers, metersToMiles, secondsToDurationObj } from "./converters";
+
+import type {
 	DistancePrecisionPreference,
 	DistanceUnitPreference,
 	LocalePreference,
 	TimeDisplayPreference,
-} from "@thingco/user-preferences";
-
-import { kmphToMph, metersToKilometers, metersToMiles, secondsToDurationObj } from "./converters";
+} from "@thingco/shared-types";
 
 export interface DistanceOpts {
 	unitPreference?: DistanceUnitPreference;

--- a/packages/user-preferences-store-native/package.json
+++ b/packages/user-preferences-store-native/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/user-preferences-store-native",
 	"description": "React Native persistance for ThingCo React apps' user preferences",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [
@@ -34,6 +34,7 @@
 	},
 	"peerDependencies": {
 		"@react-native-async-storage/async-storage": "*",
+		"@thingco/shared-types": "*",
 		"react": "*",
 		"react-native": "*"
 	}

--- a/packages/user-preferences-store-web/package.json
+++ b/packages/user-preferences-store-web/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/user-preferences-store-web",
 	"description": "Web persistance for ThingCo React apps' user preferences",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [
@@ -28,5 +28,8 @@
 		"ts-jest": "^27.0.3",
 		"typedoc": "^0.21.0",
 		"typescript": "^4.3.4"
+	},
+	"peerDependencies": {
+		"@thingco/shared-types": "*"
 	}
 }

--- a/packages/user-preferences/README.md
+++ b/packages/user-preferences/README.md
@@ -9,20 +9,27 @@ An React/React Native interface for storing user preferences ThingCo apps. Provi
 Ensure your project is set up to allow pulling `@thingco/` namespaced packages from GitHub rather than NPM.
 
 ```
-yarn add @thingco/user-preferences@0.1.0
+yarn add @thingco/user-preferences@0.6.0
 ```
 
 It is necessary to provide a store implementation. You can build one yourself -- see the respective `user-preferences-store-` implementations as an example, they're very simple. But more likely
 you will want to just use the web storage API or the React Native API. For web, you'll need React installed, then:
 
 ```
-yarn add @thingco/user-preferences-store-web@0.1.0
+yarn add @thingco/user-preferences-store-web@0.4.0
 ```
 
 For React native, you'll need React, React Native and AsyncStorage (`@react-native-async-storage/async-storage`) installed. Then:
 
 ```
-yarn add @thingco/user-preferences-store-native@0.1.0
+yarn add @thingco/user-preferences-store-native@0.4.0
+```
+
+And finally, you'll need the shared types as a dev dependency (or a normal dependency, it will make
+no difference, as they are just Typescript types):
+
+```
+yarn add -D @thingco/shared-types@0.2.0
 ```
 
 ## Setup

--- a/packages/user-preferences/package.json
+++ b/packages/user-preferences/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/user-preferences",
 	"description": "User preference storage/access for ThingCo React apps",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [
@@ -20,6 +20,7 @@
 	"devDependencies": {
 		"@testing-library/jest-dom": "^5.14.1",
 		"@testing-library/react": "^11.2.7",
+		"@thingco/shared-types": "workspace:*",
 		"@types/jest": "^26.0.23",
 		"@types/react": "^17.0.11",
 		"@types/react-dom": "^17.0.8",
@@ -33,10 +34,8 @@
 		"typedoc": "^0.21.0",
 		"typescript": "^4.3.4"
 	},
-	"dependencies": {
-		"@thingco/shared-types": "workspace:*"
-	},
 	"peerDependencies": {
+		"@thingco/shared-types": "*",
 		"react": "*"
 	}
 }

--- a/packages/user-preferences/src/user-preferences.tsx
+++ b/packages/user-preferences/src/user-preferences.tsx
@@ -105,13 +105,3 @@ export function usePrefs(): {
 		setPref: updater.updateUserPreference,
 	};
 }
-
-/**
- * Re-export the shared types.
- *
- * BE VERY CAREFUL WITH THIS. Because the types are shared, if re-exported from another package as well,
- * there is the distinct possiblity of conflicts (even though the types are actually exactly the same).
- *
- * REVIEW publish the shared types?
- */
-export * from "@thingco/shared-types";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2849,7 +2849,8 @@ __metadata:
   dependencies:
     "@testing-library/jest-dom": ^5.14.1
     "@testing-library/react": ^11.2.7
-    "@thingco/user-preferences": 0.5.0
+    "@thingco/shared-types": "workspace:*"
+    "@thingco/user-preferences": 0.6.0
     "@types/jest": ^26.0.23
     "@types/react": ^17.0.11
     "@types/react-dom": ^17.0.8
@@ -2863,6 +2864,7 @@ __metadata:
     typedoc: ^0.21.0
     typescript: ^4.3.4
   peerDependencies:
+    "@thingco/shared-types": "*"
     "@thingco/user-preferences": "*"
     react: "*"
   languageName: unknown
@@ -2887,6 +2889,7 @@ __metadata:
     typescript: ^4.3.4
   peerDependencies:
     "@react-native-async-storage/async-storage": "*"
+    "@thingco/shared-types": "*"
     react: "*"
     react-native: "*"
   languageName: unknown
@@ -2906,10 +2909,12 @@ __metadata:
     ts-jest: ^27.0.3
     typedoc: ^0.21.0
     typescript: ^4.3.4
+  peerDependencies:
+    "@thingco/shared-types": "*"
   languageName: unknown
   linkType: soft
 
-"@thingco/user-preferences@0.5.0, @thingco/user-preferences@workspace:*, @thingco/user-preferences@workspace:packages/user-preferences":
+"@thingco/user-preferences@0.6.0, @thingco/user-preferences@workspace:*, @thingco/user-preferences@workspace:packages/user-preferences":
   version: 0.0.0-use.local
   resolution: "@thingco/user-preferences@workspace:packages/user-preferences"
   dependencies:
@@ -2929,6 +2934,7 @@ __metadata:
     typedoc: ^0.21.0
     typescript: ^4.3.4
   peerDependencies:
+    "@thingco/shared-types": "*"
     react: "*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
- set package configs for shared types in preparation for publishing them
- set as a peer dependency instead of standard dependency for relevant packages

The issue is that the imported types do not get bundled: `tsc`, which generates the declaration files, does not handle types imported from other packages [the way it is currently set up in the project]. `esbuild` does not do anything with types at all. 

The behaviour that this PR fixes is that the `@thingco/user-settings` package re-exported those types. So when the package was published, the installation failed AFAICS because the package referenced files _local, using a relative path, to the files in this repo_.