### PR TITLE
fix: keys used to store persisted values are invalid on native platforms

### DIFF
--- a/.yarn/versions/63a48cdd.yml
+++ b/.yarn/versions/63a48cdd.yml
@@ -1,10 +1,10 @@
 undecided:
+  - "@thingco/auth-flows"
   - "@thingco/graphviz"
   - "@thingco/graphviz-native"
   - "@thingco/graphviz-web"
   - "@thingco/react-component-library"
   - "@thingco/shared-types"
-  - "@thingco/unit-formatter"
   - "@thingco/user-preferences"
   - "@thingco/user-preferences-store-native"
   - "@thingco/user-preferences-store-web"

--- a/packages/auth-flows/package.json
+++ b/packages/auth-flows/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/auth-flows",
 	"description": "XState-powered auth flows for React",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/packages/auth-flows/src/pin-worker.ts
+++ b/packages/auth-flows/src/pin-worker.ts
@@ -138,7 +138,7 @@ const machine = model.createMachine(
 						target: "authorised",
 					},
 					onError: {
-						actions: log("TODO: PIN SETUP FAILURE"),
+						actions: log((_, e) => e.data),
 						target: "awaitingNewPinInput",
 					},
 				},
@@ -162,7 +162,7 @@ const machine = model.createMachine(
 						target: "authorised",
 					},
 					onError: {
-						actions: log("TODO: PIN INPUT FAILURE"),
+						actions: log((_, e) => e.data),
 						target: "awaitingNewPinInput",
 					},
 				},
@@ -187,7 +187,7 @@ const machine = model.createMachine(
 						target: "authorised",
 					},
 					onError: {
-						actions: log("TODO: PIN CHANGE FAILURE"),
+						actions: log((_, e) => e.data),
 						target: "awaitingPinInputForPinChange",
 					},
 				},

--- a/packages/auth-flows/src/types.ts
+++ b/packages/auth-flows/src/types.ts
@@ -35,8 +35,8 @@ export interface UsernamePasswordService<User> {
 	logOut(): Promise<unknown>;
 }
 
-export type DeviceSecurityPinStorageKey = "@auth_device_security_pin";
-export type DeviceSecurityTypeKey = "@auth_device_security_type";
+export type DeviceSecurityPinStorageKey = "auth_device_security_pin";
+export type DeviceSecurityTypeKey = "auth_device_security_type";
 
 export interface DeviceSecurityService {
 	getDeviceSecurityType: () => Promise<DeviceSecurityType>;

--- a/packages/shared-types/index.d.ts
+++ b/packages/shared-types/index.d.ts
@@ -29,7 +29,7 @@ export interface UserPreferences {
 	timeDisplayPref: TimeDisplayPreference;
 }
 
-export type PreferenceStorageKey = "@user_preferences";
+export type PreferenceStorageKey = "user_preferences";
 
 export interface Storage {
 	getPreferences(): Promise<UserPreferences>;

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/shared-types",
 	"description": "Internal shared types for the shared-frontend-libs repo",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"main": "index.js",
 	"types": "index.d.ts",
 	"files": [

--- a/packages/unit-formatter/package.json
+++ b/packages/unit-formatter/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/unit-formatter",
 	"description": "React-based unit formatters",
-	"version": "2.0.0-rc.2",
+	"version": "1.4.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [
@@ -21,7 +21,7 @@
 		"@testing-library/jest-dom": "^5.14.1",
 		"@testing-library/react": "^12.0.0",
 		"@thingco/shared-types": "workspace:*",
-		"@thingco/user-preferences": "0.8.0",
+		"@thingco/user-preferences": "0.9.0",
 		"@types/jest": "^26.0.24",
 		"@types/react": "^17.0.14",
 		"@types/react-dom": "^17.0.9",
@@ -39,6 +39,5 @@
 		"@thingco/shared-types": "*",
 		"@thingco/user-preferences": "*",
 		"react": "*"
-	},
-	"stableVersion": "1.3.0"
+	}
 }

--- a/packages/user-preferences-store-native/package.json
+++ b/packages/user-preferences-store-native/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/user-preferences-store-native",
 	"description": "React Native persistance for ThingCo React apps' user preferences",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/packages/user-preferences-store-native/src/user-preferences-store.tsx
+++ b/packages/user-preferences-store-native/src/user-preferences-store.tsx
@@ -2,7 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import type { Storage, PreferenceStorageKey, UserPreferences } from "@thingco/shared-types";
 
-const KEY: PreferenceStorageKey = "@user_preferences";
+const KEY: PreferenceStorageKey = "user_preferences";
 
 const NO_STORED_DATA_WARNING = `
 No preferences found in storage!

--- a/packages/user-preferences-store-web/package.json
+++ b/packages/user-preferences-store-web/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/user-preferences-store-web",
 	"description": "Web persistance for ThingCo React apps' user preferences",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/packages/user-preferences-store-web/src/user-preferences-store.tsx
+++ b/packages/user-preferences-store-web/src/user-preferences-store.tsx
@@ -1,6 +1,6 @@
 import type { Storage, PreferenceStorageKey, UserPreferences } from "@thingco/shared-types";
 
-const KEY: PreferenceStorageKey = "@user_preferences";
+const KEY: PreferenceStorageKey = "user_preferences";
 
 const NO_STORED_DATA_WARNING = `
 No preferences found in storage!

--- a/packages/user-preferences/package.json
+++ b/packages/user-preferences/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/user-preferences",
 	"description": "User preference storage/access for ThingCo React apps",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2870,7 +2870,7 @@ __metadata:
     "@testing-library/jest-dom": ^5.14.1
     "@testing-library/react": ^12.0.0
     "@thingco/shared-types": "workspace:*"
-    "@thingco/user-preferences": 0.8.0
+    "@thingco/user-preferences": 0.9.0
     "@types/jest": ^26.0.24
     "@types/react": ^17.0.14
     "@types/react-dom": ^17.0.9
@@ -2934,7 +2934,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@thingco/user-preferences@0.8.0, @thingco/user-preferences@workspace:*, @thingco/user-preferences@workspace:packages/user-preferences":
+"@thingco/user-preferences@0.9.0, @thingco/user-preferences@workspace:*, @thingco/user-preferences@workspace:packages/user-preferences":
   version: 0.0.0-use.local
   resolution: "@thingco/user-preferences@workspace:packages/user-preferences"
   dependencies:


### PR DESCRIPTION
@ character that prefixed all the keys is not allowed on native.

- remove @ from PIN storage key in auth-flows
- Add logging for pin storage access failure in auth-flows
- remove @ from user preferences storage key in shared-types
- remove @ from user preferences storage key in both the user preferences store modules

Bump (minor) for shared-types, auth-flows, unit-formatter, user-preferences, user-preferences-store-native, user-preferences-store-web