### PR TITLE
49/auth flow logging

### DIFF
--- a/.yarn/versions/63a48cdd.yml
+++ b/.yarn/versions/63a48cdd.yml
@@ -1,10 +1,10 @@
 undecided:
-  - "@thingco/auth-flows"
   - "@thingco/graphviz"
   - "@thingco/graphviz-native"
   - "@thingco/graphviz-web"
   - "@thingco/react-component-library"
   - "@thingco/shared-types"
+  - "@thingco/unit-formatter"
   - "@thingco/user-preferences"
   - "@thingco/user-preferences-store-native"
   - "@thingco/user-preferences-store-web"

--- a/packages/auth-flows/package.json
+++ b/packages/auth-flows/package.json
@@ -26,6 +26,7 @@
 		"@types/rimraf": "^3.0.1",
 		"@xstate/react": "^1.5.1",
 		"@xstate/test": "^0.4.2",
+		"consola": "^2.15.3",
 		"esbuild": "^0.12.15",
 		"jest": "^27.0.6",
 		"react": "^17.0.2",
@@ -38,6 +39,7 @@
 	},
 	"peerDependencies": {
 		"@xstate/react": "*",
+		"consola": "*",
 		"react": "*",
 		"react-dom": "*",
 		"xstate": "*"

--- a/packages/auth-flows/package.json
+++ b/packages/auth-flows/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/auth-flows",
 	"description": "XState-powered auth flows for React",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/packages/auth-flows/package.json
+++ b/packages/auth-flows/package.json
@@ -26,7 +26,6 @@
 		"@types/rimraf": "^3.0.1",
 		"@xstate/react": "^1.5.1",
 		"@xstate/test": "^0.4.2",
-		"consola": "^2.15.3",
 		"esbuild": "^0.12.15",
 		"jest": "^27.0.6",
 		"react": "^17.0.2",
@@ -39,7 +38,6 @@
 	},
 	"peerDependencies": {
 		"@xstate/react": "*",
-		"consola": "*",
 		"react": "*",
 		"react-dom": "*",
 		"xstate": "*"

--- a/packages/auth-flows/src/AuthenticationProvider.tsx
+++ b/packages/auth-flows/src/AuthenticationProvider.tsx
@@ -1,7 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useMachine } from "@xstate/react";
-import React, { createContext, useContext } from "react";
+import React, { createContext, useCallback, useContext, useEffect } from "react";
 
+import { AuthSystemLogger } from "./logger";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { DeviceSecurityType, LoginFlowType, SessionCheckBehaviour } from "./types";
 import type { AuthSystemConfig, AuthSystemContext, AuthSystemEvents } from "./auth-system";
 import type { State, StateMachine } from "xstate";
@@ -26,7 +28,14 @@ export function AuthProvider<User>({
 	inWebDebugMode = false,
 	authSystem,
 }: AuthProviderProps<User>): JSX.Element {
-	const [state, send] = useMachine(authSystem, { devTools: inWebDebugMode });
+	const [state, send, service] = useMachine(authSystem, { devTools: inWebDebugMode });
+
+	useEffect(() => {
+		const logger = new AuthSystemLogger("authSystem");
+		logger.log(service.state);
+		const subscription = service.subscribe(logger.log);
+		return subscription.unsubscribe;
+	}, [service]);
 
 	return (
 		<AuthUpdateContext.Provider value={{ send }}>

--- a/packages/auth-flows/src/auth-system.ts
+++ b/packages/auth-flows/src/auth-system.ts
@@ -101,6 +101,7 @@ export type AuthStateSchema = {
 export type AuthSystemServiceRef = ActorRef<AuthSystemEvents>;
 
 const authSysytemImplementations = {
+	preserveActionOrder: true,
 	actions: {
 		spawnOtpService: authSystemModel.assign({
 			otpService: null,

--- a/packages/auth-flows/src/biometric-worker.ts
+++ b/packages/auth-flows/src/biometric-worker.ts
@@ -107,7 +107,6 @@ const machine = model.createMachine(
 export function createBiometricWorker(
 	serviceApi: DeviceSecurityService
 ): StateMachine<ModelContextFrom<typeof model>, any, ModelEventsFrom<typeof model>> {
-	console.log("Initialising biometric service worker machine...");
 	return machine.withConfig({
 		services: {
 			checkForBiometricSupport: () => serviceApi.checkForBiometricSupport(),

--- a/packages/auth-flows/src/biometric-worker.ts
+++ b/packages/auth-flows/src/biometric-worker.ts
@@ -24,6 +24,7 @@ type ModelCtx = ModelContextFrom<typeof model>;
 type ModelEvt = ModelEventsFrom<typeof model>;
 
 const implementations = {
+	preserveActionOrder: true,
 	services: {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		checkForBiometricSupport: (_c: ModelCtx, _e: ModelEvt) => {

--- a/packages/auth-flows/src/logger.ts
+++ b/packages/auth-flows/src/logger.ts
@@ -1,0 +1,86 @@
+import type { State, StateValue, Subscription } from "xstate";
+
+import type { AuthSystemContext, AuthSystemEvents } from "./auth-system";
+
+function reify<T = Record<string, unknown>>(obj: T): T {
+	return JSON.parse(JSON.stringify(obj));
+}
+
+// prettier-ignore
+type AuthSystemLoggableState = State<AuthSystemContext, AuthSystemEvents, any, { value: any; context: AuthSystemContext; }>
+
+export class AuthSystemLogger {
+	childSubscriptions: Record<string, Subscription> = {};
+	currentAuthSystemState: StateValue | null = null;
+	id: string;
+	isWorker: boolean;
+
+	constructor(id: string, isWorker = false) {
+		this.id = id;
+		this.isWorker = isWorker;
+		// for crying out loud, need to bind all of the methods because in this case,
+		// as soon as I use any of the methods in a subscription, `this` vanishes.
+		this.updateChildSubscriptions = this.updateChildSubscriptions.bind(this);
+		this.log = this.log.bind(this);
+	}
+
+	updateChildSubscriptions(s: AuthSystemLoggableState) {
+		const currentSubscriptions = Object.keys(this.childSubscriptions);
+		const currentChildren = Object.keys(s.children);
+
+		const removedSubscriptions = currentSubscriptions.filter((k) => !currentChildren.includes(k));
+		const addedSubscriptions = currentChildren.filter((k) => !currentSubscriptions.includes(k));
+
+		removedSubscriptions.forEach((subKey) => {
+			this.childSubscriptions[subKey].unsubscribe();
+			delete this.childSubscriptions[subKey];
+		});
+
+		addedSubscriptions.forEach((subKey) => {
+			const logger = new AuthSystemLogger(subKey, true);
+			this.childSubscriptions[subKey] = s.children[subKey].subscribe(logger.log);
+		});
+	}
+
+	log(s: AuthSystemLoggableState) {
+		this[(s.event.type as any) === "xstate.init" ? "initEventLog" : "standardEventLog"](s);
+		if (!this.isWorker) this.updateChildSubscriptions(s);
+	}
+
+	get logPrefix() {
+		return {
+			authSystem: "[AUTH]",
+			otpService: "┣━ [AUTH SERVICE: OTP]",
+			usernamePasswordService: "┣━ [AUTH SERVICE: username/password]",
+			pinService: "┣━ [AUTH SERVICE: PIN]",
+			biometricService: "┣━ [AUTH SERVICE: biometric]",
+		}[this.id];
+	}
+
+	get serviceInfo() {
+		// prettier-ignore
+		return {
+			"authSystem": "Initialising overall auth system. The system acts as a supervisor for the specific services used during the authorisation process",
+			"otpService": "Initialising OTP worker service. This worker handles input and validation for OTP authorisation flow",
+			"usernamePasswordService": "Initialising username/password worker service. This worker handles input and validation for username/password authorisation flow",
+			"pinService": "Initialising PIN worker service. This worker handles device-level PIN security",
+			"biometricService": "Initialising biometric worker service. This worker handles device-level biometric security"
+		}[this.id];
+	}
+
+	initEventLog(s: AuthSystemLoggableState) {
+		console.groupCollapsed("%s %s", this.logPrefix, this.serviceInfo);
+		console.log("◼ event details", reify(s.event));
+		console.log("↓ next state", reify(s));
+		console.groupEnd();
+	}
+
+	standardEventLog(s: AuthSystemLoggableState) {
+		// prettier-ignore
+		console.groupCollapsed("%s %s", this.logPrefix, s.event.type);
+		console.log("↑ prev state", reify(s.history));
+		console.log("◼ event details", reify(s.event));
+		console.log("↓ next state", reify(s));
+		console.groupEnd();
+	}
+}

--- a/packages/auth-flows/src/otp-worker.ts
+++ b/packages/auth-flows/src/otp-worker.ts
@@ -40,6 +40,7 @@ type ModelCtx = ModelContextFrom<typeof model>;
 type ModelEvt = ModelEventsFrom<typeof model>;
 
 const implementations = {
+	preserveActionOrder: true,
 	services: {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		requestOtp: (_c: ModelCtx, _e: ModelEvt) => {

--- a/packages/auth-flows/src/otp-worker.ts
+++ b/packages/auth-flows/src/otp-worker.ts
@@ -202,7 +202,6 @@ const machine = model.createMachine(
 export function createOtpWorker<User>(
 	serviceApi: OTPService<User>
 ): StateMachine<ModelCtx, any, ModelEvt> {
-	console.log("Initialising OTP service worker machine...");
 	return machine.withConfig({
 		services: {
 			requestOtp: (ctx: ModelCtx) => serviceApi.requestOtp(ctx.username),

--- a/packages/auth-flows/src/pin-worker.ts
+++ b/packages/auth-flows/src/pin-worker.ts
@@ -213,7 +213,6 @@ const machine = model.createMachine(
 export function createPinWorker(
 	serviceApi: DeviceSecurityService
 ): StateMachine<ModelCtx, any, ModelEvt> {
-	console.log("Initialising PIN service worker machine...");
 	return machine.withConfig({
 		services: {
 			changeCurrentPin: (ctx: ModelCtx) => serviceApi.changeCurrentPin(ctx.currentPin, ctx.newPin),

--- a/packages/auth-flows/src/pin-worker.ts
+++ b/packages/auth-flows/src/pin-worker.ts
@@ -36,6 +36,7 @@ type ModelCtx = ModelContextFrom<typeof model>;
 type ModelEvt = ModelEventsFrom<typeof model>;
 
 const implementations = {
+	preserveActionOrder: true,
 	services: {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		changeCurrentPin: (_c: ModelCtx, _e: ModelEvt) => {

--- a/packages/auth-flows/src/username-password-worker.ts
+++ b/packages/auth-flows/src/username-password-worker.ts
@@ -150,7 +150,6 @@ const machine = model.createMachine(
 export function createUsernamePasswordWorker<User>(
 	serviceApi: UsernamePasswordService<User>
 ): StateMachine<ModelCtx, any, ModelEvt> {
-	console.log("Initialising username/password service worker machine...");
 	return machine.withConfig({
 		services: {
 			checkForExtantSession: (ctx: ModelCtx) =>

--- a/packages/auth-flows/src/username-password-worker.ts
+++ b/packages/auth-flows/src/username-password-worker.ts
@@ -37,6 +37,7 @@ type ModelCtx = ModelContextFrom<typeof model>;
 type ModelEvt = ModelEventsFrom<typeof model>;
 
 const implementations = {
+	preserveActionOrder: true,
 	services: {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		checkForExtantSession: (_c: ModelCtx, _e: ModelEvt) => {

--- a/playground/src/application/AuthStuff.tsx
+++ b/playground/src/application/AuthStuff.tsx
@@ -70,8 +70,8 @@ const cognitoUsernamePasswordService: UsernamePasswordService<CognitoUser> = {
 	},
 };
 
-const SECURITY_TYPE_KEY: DeviceSecurityTypeKey = "@auth_device_security_type";
-const PIN_KEY: DeviceSecurityPinStorageKey = "@auth_device_security_pin";
+const SECURITY_TYPE_KEY: DeviceSecurityTypeKey = "auth_device_security_type";
+const PIN_KEY: DeviceSecurityPinStorageKey = "auth_device_security_pin";
 
 const localSecurityService: DeviceSecurityService = {
 	async getDeviceSecurityType() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,7 +2715,6 @@ __metadata:
     "@types/rimraf": ^3.0.1
     "@xstate/react": ^1.5.1
     "@xstate/test": ^0.4.2
-    consola: ^2.15.3
     esbuild: ^0.12.15
     jest: ^27.0.6
     react: ^17.0.2
@@ -2727,7 +2726,6 @@ __metadata:
     xstate: ^4.22.0
   peerDependencies:
     "@xstate/react": "*"
-    consola: "*"
     react: "*"
     react-dom: "*"
     xstate: "*"
@@ -5420,13 +5418,6 @@ __metadata:
     parseurl: ~1.3.3
     utils-merge: 1.0.1
   checksum: 96e1c4effcf219b065c7823e57351c94366d2e2a6952fa95e8212bffb35c86f1d5a3f9f6c5796d4cd3a5fdda628368b1c3cc44bf19c66cfd68fe9f9cab9177e2
-  languageName: node
-  linkType: hard
-
-"consola@npm:^2.15.3":
-  version: 2.15.3
-  resolution: "consola@npm:2.15.3"
-  checksum: 8ef7a09b703ec67ac5c389a372a33b6dc97eda6c9876443a60d76a3076eea0259e7f67a4e54fd5a52f97df73690822d090cf8b7e102b5761348afef7c6d03e28
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,6 +2715,7 @@ __metadata:
     "@types/rimraf": ^3.0.1
     "@xstate/react": ^1.5.1
     "@xstate/test": ^0.4.2
+    consola: ^2.15.3
     esbuild: ^0.12.15
     jest: ^27.0.6
     react: ^17.0.2
@@ -2726,6 +2727,7 @@ __metadata:
     xstate: ^4.22.0
   peerDependencies:
     "@xstate/react": "*"
+    consola: "*"
     react: "*"
     react-dom: "*"
     xstate: "*"
@@ -5418,6 +5420,13 @@ __metadata:
     parseurl: ~1.3.3
     utils-merge: 1.0.1
   checksum: 96e1c4effcf219b065c7823e57351c94366d2e2a6952fa95e8212bffb35c86f1d5a3f9f6c5796d4cd3a5fdda628368b1c3cc44bf19c66cfd68fe9f9cab9177e2
+  languageName: node
+  linkType: hard
+
+"consola@npm:^2.15.3":
+  version: 2.15.3
+  resolution: "consola@npm:2.15.3"
+  checksum: 8ef7a09b703ec67ac5c389a372a33b6dc97eda6c9876443a60d76a3076eea0259e7f67a4e54fd5a52f97df73690822d090cf8b7e102b5761348afef7c6d03e28
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds Reux-logger-style logging for the auth system. Will currently always run, and has no styling applied (which would be useful from a readability PoV to separate logs from auth from other logs in the console -- either browser or terminal depending on whether it's a web or native app respectively). Just functional:

<img width="1012" alt="Screenshot 2021-07-28 at 10 31 40" src="https://user-images.githubusercontent.com/573694/127299696-1f7d2777-e0df-4990-9280-96eba036d768.png">
