### PR TITLE
@thingco/logger package

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,0 +1,84 @@
+# `@thingco/logger`
+
+## Overview
+
+Logging for frontend apps.
+
+## Prerequisites
+
+- [react](https://github.com/facebook/react)
+
+## Installation
+
+If not already installed, then:
+
+```
+yarn add react
+```
+
+Then the library
+
+```
+yarn add @thingco/logger
+```
+
+## Usage
+
+The package exports two functions: the `useLogger` hook just uses the default logging implementation, `console`, and provides `info`, `log`, `warn` and `error` functions. The implementation:
+
+```ts
+type LoggerImplementation = {
+	info: (...args: any[]) => void;
+	log: (...args: any[]) => void;
+	warn: (...args: any[]) => void;
+	error: (...args: any[]) => void;
+};
+```
+
+And the usage:
+
+```tsx
+import React, { useEffect } from "react";
+import { useLogger } from "@thingco/logger";
+
+const ComponentUsingLogging = () => {
+	const logger = useLogger();
+
+	useEffect(() => {
+		logger.info("some info");
+		logger.log("a log");
+		logger.warn("a warning");
+		logger.error("oh noes!");
+	}, []);
+
+	return <p>Hello!</p>;
+};
+```
+
+`createLogger` takes an implementation, allowing you to specify your own functionality for the four funcitons, and returns a function that allows access to them. It is a factory for creating your own `useLogger` hook:
+
+```tsx
+import React, { useEffect } from "react";
+import { mySuperLoggingLibrary } from "super-duper-log";
+import { createLogger } from "@thingco/logger";
+
+const useLogger = createLogger({
+	info: mySuperLoggingLibrary.info,
+	log: mySuperLoggingLibrary.log,
+	warn: mySuperLoggingLibrary.warn,
+	error: mySuperLoggingLibrary.error,
+});
+
+const ComponentUsingCustomLogging = () => {
+	const logger = useLogger();
+
+	useEffect(() => {
+		logger.info("some info");
+		logger.log("a log");
+		logger.warn("a warning");
+		logger.error("oh noes!");
+	}, []);
+
+	return <p>Hello!</p>;
+};
+```

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -55,7 +55,7 @@ const ComponentUsingLogging = () => {
 };
 ```
 
-`createLogger` takes an implementation, allowing you to specify your own functionality for the four funcitons, and returns a function that allows access to them. It is a factory for creating your own `useLogger` hook:
+`createLogger` takes an implementation, allowing you to specify your own functionality for the four functions, and returns a function that allows access to them. It is a factory for creating your own `useLogger` hook:
 
 ```tsx
 import React, { useEffect } from "react";

--- a/packages/logger/jest.config.js
+++ b/packages/logger/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+	globals: {
+		"ts-jest": {
+			tsconfig: "tsconfig.jest.json",
+		},
+	},
+	roots: ["<rootDir>/src"],
+	testEnvironment: "jsdom",
+	testMatch: ["**/__tests__/**/*.+(ts|tsx|js)", "**/?(*.)+(spec|test).+(ts|tsx|js)"],
+	transform: {
+		"^.+\\.(js|ts|tsx)$": "ts-jest",
+	},
+	verbose: true,
+};

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,39 @@
+{
+	"name": "@thingco/logger",
+	"description": "React logging provider",
+	"version": "0.1.0",
+	"main": "lib/index.js",
+	"types": "lib/types/index.d.ts",
+	"files": [
+		"lib/**"
+	],
+	"public": true,
+	"publishConfig": {
+		"registry": "https://npm.pkg.github.com/"
+	},
+	"repository": "https://github.com/thingco/shared-frontend-libs",
+	"scripts": {
+		"build": "yarn global:build",
+		"test": "yarn jest",
+		"docs": "yarn rimraf docs && yarn typedoc"
+	},
+	"devDependencies": {
+		"@testing-library/react": "^12.0.0",
+		"@types/jest": "^26.0.24",
+		"@types/node": "^16.3.1",
+		"@types/react": "^17.0.14",
+		"@types/react-dom": "^17.0.9",
+		"@types/rimraf": "^3.0.1",
+		"esbuild": "^0.12.15",
+		"jest": "^27.0.6",
+		"react": "^17.0.2",
+		"react-dom": "^17.0.2",
+		"rimraf": "^3.0.2",
+		"ts-jest": "^27.0.3",
+		"typedoc": "^0.21.4",
+		"typescript": "^4.3.5"
+	},
+	"peerDependencies": {
+		"react": "*"
+	}
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -14,7 +14,7 @@ export function createLogger(implementation: LoggerImplementation) {
 }
 
 /**
- * Default implnentation, just using `console` functions.
+ * Default implementation, just using `console` functions.
  */
 export const useLogger = createLogger({
 	info: console.info,

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type LoggerImplementation = {
+	info: (...args: any[]) => void;
+	log: (...args: any[]) => void;
+	warn: (...args: any[]) => void;
+	error: (...args: any[]) => void;
+};
+
+/**
+ * Factory function for creating a `useLogger` hook.
+ */
+export function createLogger(implementation: LoggerImplementation) {
+	return () => implementation;
+}
+
+/**
+ * Default implnentation, just using `console` functions.
+ */
+export const useLogger = createLogger({
+	info: console.info,
+	log: console.log,
+	warn: console.warn,
+	error: console.error,
+});

--- a/packages/logger/tsconfig.jest.json
+++ b/packages/logger/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"]
+}

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"emitDeclarationOnly": true,
+		"declarationDir": "./lib/types",
+		"skipLibCheck": true,
+		"rootDir": "./src"
+	},
+	"typedocOptions": {
+		"entryPoints": ["src/index.ts"],
+		"out": "docs"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["src/**/*.test.{js,ts,tsx}"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2792,6 +2792,29 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@thingco/logger@workspace:packages/logger":
+  version: 0.0.0-use.local
+  resolution: "@thingco/logger@workspace:packages/logger"
+  dependencies:
+    "@testing-library/react": ^12.0.0
+    "@types/jest": ^26.0.24
+    "@types/node": ^16.3.1
+    "@types/react": ^17.0.14
+    "@types/react-dom": ^17.0.9
+    "@types/rimraf": ^3.0.1
+    esbuild: ^0.12.15
+    jest: ^27.0.6
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    rimraf: ^3.0.2
+    ts-jest: ^27.0.3
+    typedoc: ^0.21.4
+    typescript: ^4.3.5
+  peerDependencies:
+    react: "*"
+  languageName: unknown
+  linkType: soft
+
 "@thingco/react-component-library@workspace:packages/react-component-library":
   version: 0.0.0-use.local
   resolution: "@thingco/react-component-library@workspace:packages/react-component-library"


### PR DESCRIPTION
This provides a `useLogger` hook that can be used in packages and applications. Currently, it just uses a default of console logging, providing `info`, `log`, `warn` and `error` functions. Going forward, I'll add a logging package as a dependency to allow logs to be turned on and off via configuration setting (this is the main point of this library existing).

- create a useLogger hook and a createLogger factory function
- just use console logging atm