### PR TITLE
Feat/enhance authenticated hook

### DIFF
--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/authentication",
 	"description": "XState-powered auth flows for React",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/authentication",
 	"description": "XState-powered auth flows for React",
-	"version": "0.7.4",
+	"version": "0.7.5",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/authentication",
 	"description": "XState-powered auth flows for React",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/authentication",
 	"description": "XState-powered auth flows for React",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/authentication",
 	"description": "XState-powered auth flows for React",
-	"version": "0.7.1",
+	"version": "0.7.3",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/authentication",
 	"description": "XState-powered auth flows for React",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@thingco/authentication",
 	"description": "XState-powered auth flows for React",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"main": "lib/index.js",
 	"types": "lib/types/index.d.ts",
 	"files": [

--- a/packages/authentication/src/AuthSystemProvider.test.tsx
+++ b/packages/authentication/src/AuthSystemProvider.test.tsx
@@ -71,7 +71,7 @@ const MockCb = {
 	checkForExistingPinCb: jest.fn(),
 	validatePinCb: jest.fn((pin: string) => pin === VALID_CODE ? Promise.resolve() : Promise.reject()),
 	setNewPinCb: jest.fn((pin: string) => pin === VALID_CODE ? Promise.resolve() : Promise.reject()),
-	changePinCb: jest.fn((oldPin: string, newPin: string) => oldPin === VALID_CODE && newPin === ANOTHER_VALID_CODE ? Promise.resolve() : Promise.reject()),
+	changePinCb: jest.fn((newPin: string) => newPin === VALID_CODE ? Promise.resolve() : Promise.reject()),
 	logOutCb: jest.fn(),
 }
 

--- a/packages/authentication/src/auth-system-hook-callbacks.ts
+++ b/packages/authentication/src/auth-system-hook-callbacks.ts
@@ -81,7 +81,7 @@ export type SetNewPinCb = (pin: string) => Promise<any>;
  * Change an existing PIN. This to be used when there is already a PIN set; the `SetNewPinCb` is
  * for adding a brand-new PIN.
  */
-export type ChangePinCb = (oldPin: string, newPin: string) => Promise<any>;
+export type ChangePinCb = (newPin: string) => Promise<any>;
 
 /**
  * Submit a log out request. This shouldn't fail, but we handle the errors just in case.

--- a/packages/authentication/src/auth-system-hooks.test.ts
+++ b/packages/authentication/src/auth-system-hooks.test.ts
@@ -1,9 +1,9 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { cleanup, renderHook } from "@testing-library/react-hooks";
 
 import { AuthEvent, AuthStateId, machine } from "./auth-system";
 import * as AuthHook from "./auth-system-hooks";
 
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* ========================================================================= *\
@@ -24,8 +24,8 @@ import * as AuthHook from "./auth-system-hooks";
  *
  * @example
  * ```
- * > stateIdToHookName("awaitingSessionCheck")
- * "useAwaitingSessionCheck"
+ * > stateIdToHookName("CheckingForSession")
+ * "useCheckingForSession"
  * ```
  */
 function stateIdToHookName(stateId: AuthStateId) {
@@ -139,7 +139,7 @@ const USER_OBJECT = { description: "I represent the user object returned by the 
 
 const hookTestMap: HookTestMap = [
 	{
-		stateId: AuthStateId.awaitingSessionCheck,
+		stateId: AuthStateId.CheckingForSession,
 		hookSpec: {
 			primaryMethod: "checkSession",
 			callbacks: [
@@ -157,7 +157,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.awaitingOtpUsername,
+		stateId: AuthStateId.SubmittingOtpUsername,
 		hookSpec: {
 			primaryMethod: "validateUsername",
 			callbacks: [
@@ -179,7 +179,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.awaitingOtp,
+		stateId: AuthStateId.SubmittingOtp,
 		hookSpec: {
 			primaryMethod: "validateOtp",
 			callbacks: [
@@ -207,7 +207,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.awaitingUsernameAndPassword,
+		stateId: AuthStateId.SubmittingUsernameAndPassword,
 		hookSpec: {
 			primaryMethod: "validateUsernameAndPassword",
 			callbacks: [
@@ -245,7 +245,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.awaitingForcedChangePassword,
+		stateId: AuthStateId.SubmittingForceChangePassword,
 		hookSpec: {
 			primaryMethod: "validateNewPassword",
 			callbacks: [
@@ -263,7 +263,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.awaitingPasswordResetRequest,
+		stateId: AuthStateId.RequestingPasswordReset,
 		hookSpec: {
 			primaryMethod: "requestNewPassword",
 			callbacks: [
@@ -284,7 +284,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.awaitingPasswordResetSubmission,
+		stateId: AuthStateId.SubmittingPasswordReset,
 		hookSpec: {
 			primaryMethod: "submitNewPassword",
 			callbacks: [
@@ -302,7 +302,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.awaitingChangePassword,
+		stateId: AuthStateId.ChangingPassword,
 		hookSpec: {
 			primaryMethod: "submitNewPassword",
 			callbacks: [
@@ -323,7 +323,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.pinChecks,
+		stateId: AuthStateId.CheckingForPin,
 		hookSpec: {
 			primaryMethod: "checkForExistingPin",
 			callbacks: [
@@ -341,7 +341,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.awaitingCurrentPinInput,
+		stateId: AuthStateId.SubmittingCurrentPin,
 		hookSpec: {
 			primaryMethod: "validatePin",
 			callbacks: [
@@ -362,7 +362,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.resettingPin,
+		stateId: AuthStateId.ResettingPin,
 		hookSpec: {
 			primaryMethod: "resetPin",
 			callbacks: [
@@ -383,7 +383,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.awaitingNewPinInput,
+		stateId: AuthStateId.SubmittingNewPin,
 		hookSpec: {
 			primaryMethod: "setNewPin",
 			callbacks: [
@@ -401,7 +401,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.awaitingChangePinInput,
+		stateId: AuthStateId.ChangingPin,
 		hookSpec: {
 			primaryMethod: "changePin",
 			callbacks: [
@@ -422,7 +422,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.loggingOut,
+		stateId: AuthStateId.LoggingOut,
 		hookSpec: {
 			primaryMethod: "logOut",
 			callbacks: [
@@ -441,7 +441,7 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
-		stateId: AuthStateId.authenticated,
+		stateId: AuthStateId.Authenticated,
 		hookSpec: {
 			additionalMethods: [
 				{ method: "requestLogOut", expectedEvent: { type: "REQUEST_LOG_OUT" } },

--- a/packages/authentication/src/auth-system-hooks.test.ts
+++ b/packages/authentication/src/auth-system-hooks.test.ts
@@ -127,8 +127,6 @@ const INVALID_USERNAME = "invaliduser@example.com";
 
 const VALID_CODE = "123456";
 const INVALID_CODE = "654321";
-const ANOTHER_VALID_CODE = "123456";
-const ANOTHER_INVALID_CODE = "654321";
 
 const VALID_PASSWORD = "validpassword";
 const ANOTHER_VALID_PASSWORD = "anothervalidpassword";
@@ -401,17 +399,35 @@ const hookTestMap: HookTestMap = [
 		},
 	},
 	{
+		stateId: AuthStateId.ValidatingPin,
+		hookSpec: {
+			primaryMethod: "validatePin",
+			callbacks: [
+				{
+					args: [VALID_CODE],
+					callback: jest.fn(() => Promise.resolve()),
+					expectedEvent: { type: "PIN_VALID" },
+				},
+				{
+					args: [INVALID_CODE],
+					callback: jest.fn(() => Promise.reject()),
+					expectedEvent: { type: "PIN_INVALID", error: "PIN_INVALID" },
+				},
+			],
+		},
+	},
+	{
 		stateId: AuthStateId.ChangingPin,
 		hookSpec: {
 			primaryMethod: "changePin",
 			callbacks: [
 				{
-					args: [VALID_CODE, ANOTHER_VALID_CODE],
+					args: [VALID_CODE],
 					callback: jest.fn(() => Promise.resolve()),
 					expectedEvent: { type: "PIN_CHANGE_SUCCESS" },
 				},
 				{
-					args: [INVALID_CODE, ANOTHER_INVALID_CODE],
+					args: [INVALID_CODE],
 					callback: jest.fn(() => Promise.reject()),
 					expectedEvent: { type: "PIN_CHANGE_FAILURE", error: "PIN_CHANGE_FAILURE" },
 				},

--- a/packages/authentication/src/auth-system-hooks.test.ts
+++ b/packages/authentication/src/auth-system-hooks.test.ts
@@ -414,6 +414,9 @@ const hookTestMap: HookTestMap = [
 					expectedEvent: { type: "PIN_INVALID", error: "PIN_INVALID" },
 				},
 			],
+			additionalMethods: [
+				{ method: "cancelChangePin", expectedEvent: { type: "CANCEL_PIN_CHANGE" } },
+			],
 		},
 	},
 	{

--- a/packages/authentication/src/auth-system-hooks.ts
+++ b/packages/authentication/src/auth-system-hooks.ts
@@ -678,11 +678,15 @@ export function useValidatingPin(cb: AuthCb.ValidatePinCb) {
 		[authenticator, isActive]
 	);
 
+	// Need a way to back out of change pin stage
+	const cancelChangePin = () => authenticator.send({ type: "CANCEL_PIN_CHANGE" });
+
 	return {
 		error,
 		isActive,
 		isLoading,
 		validatePin,
+		cancelChangePin,
 	};
 }
 

--- a/packages/authentication/src/auth-system-hooks.ts
+++ b/packages/authentication/src/auth-system-hooks.ts
@@ -2,7 +2,7 @@ import { useLogger } from "@thingco/logger";
 import { useSelector } from "@xstate/react";
 import { useCallback, useState } from "react";
 
-import { AuthStateId, AuthStateId } from "./auth-system";
+import { AuthStateId } from "./auth-system";
 import { useAuthInterpreter } from "./AuthSystemProvider";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -651,7 +651,7 @@ export function useChangingPassword(cb: AuthCb.ChangePasswordCb) {
 export function useValidatingPin(cb: AuthCb.ValidatePinCb) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isSubmittingCurrentPin!);
+	const isActive = useSelector(authenticator, stateSelectors.isValidatingPin!);
 	const logger = useLogger();
 
 	const [isLoading, setIsLoading] = useState(false);

--- a/packages/authentication/src/auth-system-hooks.ts
+++ b/packages/authentication/src/auth-system-hooks.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { useLogger } from "@thingco/logger";
 import { useSelector } from "@xstate/react";
 import { useCallback, useState } from "react";
@@ -7,6 +5,8 @@ import { useCallback, useState } from "react";
 import { AuthStateId } from "./auth-system";
 import { useAuthInterpreter } from "./AuthSystemProvider";
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type { AuthContext, AuthState } from "./auth-system";
 import type * as AuthCb from "./auth-system-hook-callbacks";
 
@@ -30,13 +30,13 @@ type ExposedStateId = Exclude<
 	AuthStateId.INTERNAL__deviceSecurityCheck | AuthStateId.INTERNAL__loginFlowCheck
 >;
 
-/** Filter on the state ID enum to extract states only useful when a user is authenticated. */
+/** Filter on the state ID enum to extract states only useful when a user is Authenticated. */
 type AuthenticatedStateId = Extract<
 	AuthStateId,
-	| AuthStateId.authenticated
-	| AuthStateId.loggingOut
-	| AuthStateId.awaitingChangePassword
-	| AuthStateId.awaitingChangePinInput
+	| AuthStateId.Authenticated
+	| AuthStateId.LoggingOut
+	| AuthStateId.ChangingPassword
+	| AuthStateId.ChangingPin
 >;
 
 /* ========================================================================= *\
@@ -62,30 +62,30 @@ type ExposedStateSelectorMap = {
 /** Map of every state exposed to users -> match function for that state (_ie_ `true` if in state) */
 // prettier-ignore
 const stateSelectors: ExposedStateSelectorMap = {
-	isAwaitingSessionCheck: (state) => state.matches(AuthStateId.awaitingSessionCheck),
-	isAwaitingOtpUsername: (state) => state.matches(AuthStateId.awaitingOtpUsername),
-	isAwaitingOtp: (state) => state.matches(AuthStateId.awaitingOtp),
-	isAwaitingUsernameAndPassword: (state) => state.matches(AuthStateId.awaitingUsernameAndPassword),
-	isAwaitingForcedChangePassword: (state) => state.matches(AuthStateId.awaitingForcedChangePassword),
-	isAwaitingChangePassword: (state) => state.matches(AuthStateId.awaitingChangePassword),
-	isAwaitingPasswordResetRequest: (state) => state.matches(AuthStateId.awaitingPasswordResetRequest),
-	isAwaitingPasswordResetSubmission: (state) => state.matches(AuthStateId.awaitingPasswordResetSubmission),
-	isPinChecks: (state) => state.matches(AuthStateId.pinChecks),
-	isAwaitingCurrentPinInput: (state) => state.matches(AuthStateId.awaitingCurrentPinInput),
-	isAwaitingNewPinInput: (state) => state.matches(AuthStateId.awaitingNewPinInput),
-	isAwaitingChangePinInput: (state) => state.matches(AuthStateId.awaitingChangePinInput),
-	isResettingPin: (state) => state.matches(AuthStateId.resettingPin),
-	isLoggingOut: (state) => state.matches(AuthStateId.loggingOut),
-	isAuthenticated: (state) => state.matches(AuthStateId.authenticated),
+	isCheckingForSession: (state) => state.matches(AuthStateId.CheckingForSession),
+	isSubmittingOtpUsername: (state) => state.matches(AuthStateId.SubmittingOtpUsername),
+	isSubmittingOtp: (state) => state.matches(AuthStateId.SubmittingOtp),
+	isSubmittingUsernameAndPassword: (state) => state.matches(AuthStateId.SubmittingUsernameAndPassword),
+	isSubmittingForceChangePassword: (state) => state.matches(AuthStateId.SubmittingForceChangePassword),
+	isChangingPassword: (state) => state.matches(AuthStateId.ChangingPassword),
+	isRequestingPasswordReset: (state) => state.matches(AuthStateId.RequestingPasswordReset),
+	isSubmittingPasswordReset: (state) => state.matches(AuthStateId.SubmittingPasswordReset),
+	isCheckingForPin: (state) => state.matches(AuthStateId.CheckingForPin),
+	isSubmittingCurrentPin: (state) => state.matches(AuthStateId.SubmittingCurrentPin),
+	isSubmittingNewPin: (state) => state.matches(AuthStateId.SubmittingNewPin),
+	isChangingPin: (state) => state.matches(AuthStateId.ChangingPin),
+	isResettingPin: (state) => state.matches(AuthStateId.ResettingPin),
+	isLoggingOut: (state) => state.matches(AuthStateId.LoggingOut),
+	isAuthenticated: (state) => state.matches(AuthStateId.Authenticated),
 };
 
-/** Selector specifically for states only useful when a user is authenticated. */
+/** Selector specifically for states only useful when a user is Authenticated. */
 const isInStateAccessibleWhileAuthenticated = (state: AuthState): boolean => {
 	return (
-		state.matches<AuthenticatedStateId>(AuthStateId.authenticated) ||
-		state.matches<AuthenticatedStateId>(AuthStateId.awaitingChangePinInput) ||
-		state.matches<AuthenticatedStateId>(AuthStateId.awaitingChangePassword) ||
-		state.matches<AuthenticatedStateId>(AuthStateId.loggingOut)
+		state.matches<AuthenticatedStateId>(AuthStateId.Authenticated) ||
+		state.matches<AuthenticatedStateId>(AuthStateId.ChangingPin) ||
+		state.matches<AuthenticatedStateId>(AuthStateId.ChangingPassword) ||
+		state.matches<AuthenticatedStateId>(AuthStateId.LoggingOut)
 	);
 };
 
@@ -109,14 +109,14 @@ const contextSelectors: ContextSelectorMap = {
  * 3. AUTH STAGE HOOKS
  *
  * These hooks cover all stages of the authentication process where a user
- * is **not** authenticated. They all follow a common pattern, taking a
+ * is **not** Authenticated. They all follow a common pattern, taking a
  * callback of a specified shape which is then executed by the hook, allowing
  * us to specify exactly when events will be sent into the FSM system.
 \* ========================================================================= */
-export function useAwaitingSessionCheck(cb: AuthCb.CheckSessionCb) {
+export function useCheckingForSession(cb: AuthCb.CheckSessionCb) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isAwaitingSessionCheck!);
+	const isActive = useSelector(authenticator, stateSelectors.isCheckingForSession!);
 	const logger = useLogger();
 
 	const [isLoading, setIsLoading] = useState(false);
@@ -147,10 +147,10 @@ export function useAwaitingSessionCheck(cb: AuthCb.CheckSessionCb) {
 	};
 }
 
-export function useAwaitingOtpUsername<User = any>(cb: AuthCb.ValidateOtpUsernameCb<User>) {
+export function useSubmittingOtpUsername<User = any>(cb: AuthCb.ValidateOtpUsernameCb<User>) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isAwaitingOtpUsername!);
+	const isActive = useSelector(authenticator, stateSelectors.isSubmittingOtpUsername!);
 	const logger = useLogger();
 
 	const [isLoading, setIsLoading] = useState(false);
@@ -185,10 +185,10 @@ export function useAwaitingOtpUsername<User = any>(cb: AuthCb.ValidateOtpUsernam
 	};
 }
 
-export function useAwaitingOtp<User = any>(cb: AuthCb.ValidateOtpCb<User>) {
+export function useSubmittingOtp<User = any>(cb: AuthCb.ValidateOtpCb<User>) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isAwaitingOtp!);
+	const isActive = useSelector(authenticator, stateSelectors.isSubmittingOtp!);
 	const currentUserData = useSelector(authenticator, contextSelectors.user);
 	const logger = useLogger();
 
@@ -252,12 +252,12 @@ function newPasswordIsRequired<User = any>(user: User) {
 	return "NEW_PASSWORD_REQUIRED" in user;
 }
 
-export function useAwaitingUsernameAndPassword<User = any>(
+export function useSubmittingUsernameAndPassword<User = any>(
 	cb: AuthCb.ValidateUsernameAndPasswordCb<User>
 ) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isAwaitingUsernameAndPassword!);
+	const isActive = useSelector(authenticator, stateSelectors.isSubmittingUsernameAndPassword!);
 	const logger = useLogger();
 
 	const [isLoading, setIsLoading] = useState(false);
@@ -306,12 +306,12 @@ export function useAwaitingUsernameAndPassword<User = any>(
 	};
 }
 
-export function useAwaitingForcedChangePassword<User = any>(
+export function useSubmittingForceChangePassword<User = any>(
 	cb: AuthCb.ValidateForceChangePasswordCb<User>
 ) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isAwaitingForcedChangePassword!);
+	const isActive = useSelector(authenticator, stateSelectors.isSubmittingForceChangePassword!);
 	const currentUserData = useSelector(authenticator, contextSelectors.user);
 	const logger = useLogger();
 
@@ -349,10 +349,10 @@ export function useAwaitingForcedChangePassword<User = any>(
  * will be stored, to be passed onto the next request (submitting a new password + the confirmation
  * code they have been sent).
  */
-export function useAwaitingPasswordResetRequest(cb: AuthCb.RequestNewPasswordCb) {
+export function useRequestingPasswordReset(cb: AuthCb.RequestNewPasswordCb) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isAwaitingPasswordResetRequest!);
+	const isActive = useSelector(authenticator, stateSelectors.isRequestingPasswordReset!);
 	const username = useSelector(authenticator, contextSelectors.username);
 	const logger = useLogger();
 
@@ -384,10 +384,10 @@ export function useAwaitingPasswordResetRequest(cb: AuthCb.RequestNewPasswordCb)
 	};
 }
 
-export function useAwaitingPasswordResetSubmission(cb: AuthCb.SubmitNewPasswordCb) {
+export function useSubmittingPasswordReset(cb: AuthCb.SubmitNewPasswordCb) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isAwaitingPasswordResetSubmission!);
+	const isActive = useSelector(authenticator, stateSelectors.isSubmittingPasswordReset!);
 	const username = useSelector(authenticator, contextSelectors.username);
 	const logger = useLogger();
 
@@ -424,10 +424,10 @@ export function useAwaitingPasswordResetSubmission(cb: AuthCb.SubmitNewPasswordC
  * of a pin. From this, can infer whether the system should move the user to
  * inputting their current PIN or creating a new one.
  */
-export function usePinChecks(cb: AuthCb.CheckForExistingPinCb) {
+export function useCheckingForPin(cb: AuthCb.CheckForExistingPinCb) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isPinChecks!);
+	const isActive = useSelector(authenticator, stateSelectors.isCheckingForPin!);
 	const logger = useLogger();
 
 	const [isLoading, setIsLoading] = useState(false);
@@ -459,10 +459,10 @@ export function usePinChecks(cb: AuthCb.CheckForExistingPinCb) {
 	};
 }
 
-export function useAwaitingCurrentPinInput(cb: AuthCb.ValidatePinCb) {
+export function useSubmittingCurrentPin(cb: AuthCb.ValidatePinCb) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isAwaitingCurrentPinInput!);
+	const isActive = useSelector(authenticator, stateSelectors.isSubmittingCurrentPin!);
 	const logger = useLogger();
 
 	const [isLoading, setIsLoading] = useState(false);
@@ -540,10 +540,10 @@ export function useResettingPin(cb: AuthCb.LogoutCb) {
 	};
 }
 
-export function useAwaitingNewPinInput(cb: AuthCb.SetNewPinCb) {
+export function useSubmittingNewPin(cb: AuthCb.SetNewPinCb) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isAwaitingNewPinInput!);
+	const isActive = useSelector(authenticator, stateSelectors.isSubmittingNewPin!);
 	const logger = useLogger();
 
 	const [isLoading, setIsLoading] = useState(false);
@@ -552,7 +552,7 @@ export function useAwaitingNewPinInput(cb: AuthCb.SetNewPinCb) {
 		async (pin: string) => {
 			setIsLoading(true);
 			// prettier-ignore
-			logger.info("Attempting to set a new PIN. If the check resolves, attempts was successful and they are now authenticated. If it fails there may be a problem with saving to storage.");
+			logger.info("Attempting to set a new PIN. If the check resolves, attempts was successful and they are now Authenticated. If it fails there may be a problem with saving to storage.");
 
 			try {
 				const res = await cb(pin);
@@ -582,7 +582,7 @@ export function useAwaitingNewPinInput(cb: AuthCb.SetNewPinCb) {
  * 4. AUTHORISED HOOKS
  *
  * These hooks cover all stages of the authentication process where a user
- * **is** authenticated (or, in the case of `isAuthenticated`, one or the other).
+ * **is** Authenticated (or, in the case of `isAuthenticated`, one or the other).
  * 
  * Bar the core `isAuthenticated` hook, these still follow the common pattern,
  * with a callback of a specified shape which is then executed by the hook, allowing
@@ -610,10 +610,10 @@ export function useAuthenticated() {
 	};
 }
 
-export function useAwaitingChangePassword(cb: AuthCb.ChangePasswordCb) {
+export function useChangingPassword(cb: AuthCb.ChangePasswordCb) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isAwaitingChangePassword!);
+	const isActive = useSelector(authenticator, stateSelectors.isChangingPassword!);
 	const logger = useLogger();
 
 	const [isLoading, setIsLoading] = useState(false);
@@ -647,10 +647,10 @@ export function useAwaitingChangePassword(cb: AuthCb.ChangePasswordCb) {
 	};
 }
 
-export function useAwaitingChangePinInput(cb: AuthCb.ChangePinCb) {
+export function useChangingPin(cb: AuthCb.ChangePinCb) {
 	const authenticator = useAuthInterpreter();
 	const error = useSelector(authenticator, contextSelectors.error);
-	const isActive = useSelector(authenticator, stateSelectors.isAwaitingChangePinInput!);
+	const isActive = useSelector(authenticator, stateSelectors.isChangingPin!);
 	const logger = useLogger();
 
 	const [isLoading, setIsLoading] = useState(false);
@@ -659,7 +659,7 @@ export function useAwaitingChangePinInput(cb: AuthCb.ChangePinCb) {
 		async (oldPin: string, newPin: string) => {
 			setIsLoading(true);
 			// prettier-ignore
-			logger.info("Attempting to change the current PIN. If the check resolves, attempts was successful and they may return to the authenticated state.");
+			logger.info("Attempting to change the current PIN. If the check resolves, attempts was successful and they may return to the Authenticated state.");
 
 			try {
 				const res = await cb(oldPin, newPin);

--- a/packages/authentication/src/auth-system-hooks.ts
+++ b/packages/authentication/src/auth-system-hooks.ts
@@ -36,6 +36,7 @@ type AuthenticatedStateId = Extract<
 	| AuthStateId.Authenticated
 	| AuthStateId.LoggingOut
 	| AuthStateId.ChangingPassword
+	| AuthStateId.ValidatingPin
 	| AuthStateId.ChangingPin
 >;
 
@@ -84,6 +85,7 @@ const stateSelectors: ExposedStateSelectorMap = {
 const isInStateAccessibleWhileAuthenticated = (state: AuthState): boolean => {
 	return (
 		state.matches<AuthenticatedStateId>(AuthStateId.Authenticated) ||
+		state.matches<AuthenticatedStateId>(AuthStateId.ValidatingPin) ||
 		state.matches<AuthenticatedStateId>(AuthStateId.ChangingPin) ||
 		state.matches<AuthenticatedStateId>(AuthStateId.ChangingPassword) ||
 		state.matches<AuthenticatedStateId>(AuthStateId.LoggingOut)

--- a/packages/authentication/src/auth-system.test.ts
+++ b/packages/authentication/src/auth-system.test.ts
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { createModel } from "@xstate/test";
 import { createMachine, interpret } from "xstate";
 
 import { AuthStateId, createAuthenticationSystem, machine } from "./auth-system";
 import { AuthError } from "./types";
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { AuthEvent, AuthInterpreter } from "./auth-system";
 
 /* ========================================================================= *\
@@ -34,8 +34,8 @@ describe("sanity checks for the overall auth system", () => {
 		expect(statesDefinedInMachine).toEqual(expect.arrayContaining(statesDefinedInEnum));
 	});
 
-	it("should start in an initial state of 'awaitingSessionCheck'", () => {
-		expect(machine.initial).toEqual(AuthStateId.awaitingSessionCheck);
+	it("should start in an initial state of 'CheckingForSession'", () => {
+		expect(machine.initial).toEqual(AuthStateId.CheckingForSession);
 	});
 });
 
@@ -70,12 +70,12 @@ describe("authentication test system using OTP (ignoring device security)", () =
 		states: {
 			checkingSession: {
 				on: {
-					THERE_IS_A_SESSION: "authenticated",
+					THERE_IS_A_SESSION: "Authenticated",
 					THERE_IS_NO_SESSION: "submittingUsername",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingSessionCheck));
+						expect(service.state.matches(AuthStateId.CheckingForSession));
 					},
 				},
 			},
@@ -86,7 +86,7 @@ describe("authentication test system using OTP (ignoring device security)", () =
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingOtpUsername));
+						expect(service.state.matches(AuthStateId.SubmittingOtpUsername));
 					},
 				},
 			},
@@ -96,7 +96,7 @@ describe("authentication test system using OTP (ignoring device security)", () =
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingOtpUsername));
+						expect(service.state.matches(AuthStateId.SubmittingOtpUsername));
 						expect(service.state.context.error).toBe("PASSWORD_RETRIES_EXCEEDED");
 					},
 				},
@@ -107,20 +107,20 @@ describe("authentication test system using OTP (ignoring device security)", () =
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingOtpUsername));
+						expect(service.state.matches(AuthStateId.SubmittingOtpUsername));
 						expect(service.state.context.error).toBe("USERNAME_INVALID");
 					},
 				},
 			},
 			submittingOtp1: {
 				on: {
-					GOOD_OTP: "authenticated",
+					GOOD_OTP: "Authenticated",
 					BAD_OTP_1: "submittingOtp2",
 					REENTER_USERNAME: "submittingUsername",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingOtp));
+						expect(service.state.matches(AuthStateId.SubmittingOtp));
 						expect(service.state.context.username).toBe(VALID_USERNAME);
 						expect(service.state.context.user).toBe(USER_OBJECT);
 					},
@@ -132,7 +132,7 @@ describe("authentication test system using OTP (ignoring device security)", () =
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingOtp));
+						expect(service.state.matches(AuthStateId.SubmittingOtp));
 						expect(service.state.context.error).toBe("PASSWORD_INVALID_2_RETRIES_REMAINING");
 						expect(service.state.context.username).toBe(VALID_USERNAME);
 						expect(service.state.context.user).toBe(USER_OBJECT);
@@ -145,32 +145,32 @@ describe("authentication test system using OTP (ignoring device security)", () =
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingOtp));
+						expect(service.state.matches(AuthStateId.SubmittingOtp));
 						expect(service.state.context.error).toBe("PASSWORD_INVALID_1_RETRIES_REMAINING");
 						expect(service.state.context.username).toBe(VALID_USERNAME);
 						expect(service.state.context.user).toBe(USER_OBJECT);
 					},
 				},
 			},
-			authenticated: {
+			Authenticated: {
 				on: {
-					CAN_I_LOG_OUT_PLEASE: "loggingOut",
+					CAN_I_LOG_OUT_PLEASE: "LoggingOut",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.authenticated));
+						expect(service.state.matches(AuthStateId.Authenticated));
 					},
 				},
 			},
-			loggingOut: {
+			LoggingOut: {
 				on: {
 					LOG_OUT_WORKED: "checkingSession",
-					LOG_OUT_FAILED: "authenticated",
-					ACTUALLY_NO_STAY_LOGGED_IN: "authenticated",
+					LOG_OUT_FAILED: "Authenticated",
+					ACTUALLY_NO_STAY_LOGGED_IN: "Authenticated",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.loggingOut));
+						expect(service.state.matches(AuthStateId.LoggingOut));
 					},
 				},
 			},
@@ -225,58 +225,58 @@ describe("authentication test system using username and password (ignoring devic
 		states: {
 			checkingSession: {
 				on: {
-					THERE_IS_A_SESSION: "authenticated",
+					THERE_IS_A_SESSION: "Authenticated",
 					THERE_IS_NO_SESSION: "submittingUsernameAndPassword",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingSessionCheck));
+						expect(service.state.matches(AuthStateId.CheckingForSession));
 					},
 				},
 			},
 			submittingUsernameAndPassword: {
 				on: {
-					GOOD_LOGIN: "authenticated",
+					GOOD_LOGIN: "Authenticated",
 					GOOD_LOGIN_BUT_YOU_HAVE_A_TEMPORARY_PASSWORD: "submittingChangeTemporaryPassword",
 					BAD_LOGIN: "usernameAndPasswordError",
 					FORGOT_PASSWORD: "forgotPasswordRequestANewOne",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingUsernameAndPassword));
+						expect(service.state.matches(AuthStateId.SubmittingUsernameAndPassword));
 					},
 				},
 			},
 			usernameAndPasswordError: {
 				on: {
-					GOOD_LOGIN_ON_SECOND_ATTEMPT: "authenticated",
+					GOOD_LOGIN_ON_SECOND_ATTEMPT: "Authenticated",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingUsernameAndPassword));
+						expect(service.state.matches(AuthStateId.SubmittingUsernameAndPassword));
 						expect(service.state.context.error).toBe("USERNAME_AND_PASSWORD_INVALID" as AuthError);
 					},
 				},
 			},
 			submittingChangeTemporaryPassword: {
 				on: {
-					ATTEMPT_TO_CHANGE_TEMPORARY_PASSWORD_SUCCEEDED: "authenticated",
+					ATTEMPT_TO_CHANGE_TEMPORARY_PASSWORD_SUCCEEDED: "Authenticated",
 					ATTEMPT_TO_CHANGE_TEMPORARY_PASSWORD_FAILED: "submittingChangeTemporaryPasswordError",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingForcedChangePassword));
+						expect(service.state.matches(AuthStateId.SubmittingForceChangePassword));
 						expect(service.state.context.error).toBe("PASSWORD_CHANGE_REQUIRED" as AuthError);
 					},
 				},
 			},
 			submittingChangeTemporaryPasswordError: {
 				on: {
-					ATTEMPT_TO_CHANGE_TEMPORARY_PASSWORD_SUCCEEDED_ON_SECOND_ATTEMPT: "authenticated",
+					ATTEMPT_TO_CHANGE_TEMPORARY_PASSWORD_SUCCEEDED_ON_SECOND_ATTEMPT: "Authenticated",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingForcedChangePassword));
+						expect(service.state.matches(AuthStateId.SubmittingForceChangePassword));
 						expect(service.state.context.error).toBe("PASSWORD_CHANGE_FAILURE" as AuthError);
 					},
 				},
@@ -288,7 +288,7 @@ describe("authentication test system using username and password (ignoring devic
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingPasswordResetRequest));
+						expect(service.state.matches(AuthStateId.RequestingPasswordReset));
 					},
 				},
 			},
@@ -298,29 +298,29 @@ describe("authentication test system using username and password (ignoring devic
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingPasswordResetRequest));
+						expect(service.state.matches(AuthStateId.RequestingPasswordReset));
 						expect(service.state.context.error).toBe("PASSWORD_RESET_REQUEST_FAILURE" as AuthError);
 					},
 				},
 			},
 			forgotPasswordSubmitANewOne: {
 				on: {
-					RESET_CODE_AND_NEW_PASSWORD_ARE_FINE: "authenticated",
+					RESET_CODE_AND_NEW_PASSWORD_ARE_FINE: "Authenticated",
 					RESET_CODE_AND_NEW_PASSWORD_ARE_NOT_FINE: "forgotPasswordSubmitANewOneError",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingPasswordResetSubmission));
+						expect(service.state.matches(AuthStateId.SubmittingPasswordReset));
 					},
 				},
 			},
 			forgotPasswordSubmitANewOneError: {
 				on: {
-					RESET_CODE_AND_NEW_PASSWORD_ARE_FINE_ON_SECOND_ATTEMPT: "authenticated",
+					RESET_CODE_AND_NEW_PASSWORD_ARE_FINE_ON_SECOND_ATTEMPT: "Authenticated",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingPasswordResetSubmission));
+						expect(service.state.matches(AuthStateId.SubmittingPasswordReset));
 						/*
 						 * FIXME there is a test failure here. ATM, the way errors are
 						 * assigned and cleared causes this part to flip back and forth between
@@ -339,35 +339,35 @@ describe("authentication test system using username and password (ignoring devic
 			},
 			submitPasswordChange: {
 				on: {
-					PASSWORD_CHANGE_IS_FINE: "authenticated",
-					CANCEL_PASSWORD_CHANGE: "authenticated",
+					PASSWORD_CHANGE_IS_FINE: "Authenticated",
+					CANCEL_PASSWORD_CHANGE: "Authenticated",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingChangePassword));
+						expect(service.state.matches(AuthStateId.ChangingPassword));
 					},
 				},
 			},
-			authenticated: {
+			Authenticated: {
 				on: {
-					CAN_I_LOG_OUT_PLEASE: "loggingOut",
+					CAN_I_LOG_OUT_PLEASE: "LoggingOut",
 					CAN_I_CHANGE_MY_PASSWORD: "submitPasswordChange",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.authenticated));
+						expect(service.state.matches(AuthStateId.Authenticated));
 					},
 				},
 			},
-			loggingOut: {
+			LoggingOut: {
 				on: {
 					LOG_OUT_WORKED: "checkingSession",
-					LOG_OUT_FAILED: "authenticated",
-					ACTUALLY_NO_STAY_LOGGED_IN: "authenticated",
+					LOG_OUT_FAILED: "Authenticated",
+					ACTUALLY_NO_STAY_LOGGED_IN: "Authenticated",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.loggingOut));
+						expect(service.state.matches(AuthStateId.LoggingOut));
 					},
 				},
 			},
@@ -433,42 +433,42 @@ describe("authentication test system for PIN (ignoring login flow)", () => {
 		states: {
 			checkingSession: {
 				on: {
-					THERE_IS_A_SESSION: "pinChecks",
+					THERE_IS_A_SESSION: "CheckingForPin",
 					THERE_IS_NO_SESSION: "otpFlowStart",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingSessionCheck));
+						expect(service.state.matches(AuthStateId.CheckingForSession));
 					},
 				},
 			},
 			otpFlowStart: {
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingOtpUsername));
+						expect(service.state.matches(AuthStateId.SubmittingOtpUsername));
 					},
 				},
 			},
-			pinChecks: {
+			CheckingForPin: {
 				on: {
 					THERE_IS_A_PIN_SET: "submitCurrentPin",
 					THERE_IS_NO_PIN_SET: "setANewPin",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.pinChecks));
+						expect(service.state.matches(AuthStateId.CheckingForPin));
 					},
 				},
 			},
 			submitCurrentPin: {
 				on: {
-					PIN_SUBMITTED_WAS_CORRECT: "authenticated",
+					PIN_SUBMITTED_WAS_CORRECT: "Authenticated",
 					PIN_SUBMITTED_WAS_NOT_CORRECT: "incorrectCurrentPin",
 					I_FORGOT_MY_PIN: "resetPin",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingCurrentPinInput));
+						expect(service.state.matches(AuthStateId.SubmittingCurrentPin));
 					},
 				},
 			},
@@ -480,7 +480,7 @@ describe("authentication test system for PIN (ignoring login flow)", () => {
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.resettingPin));
+						expect(service.state.matches(AuthStateId.ResettingPin));
 					},
 				},
 			},
@@ -490,74 +490,74 @@ describe("authentication test system for PIN (ignoring login flow)", () => {
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.resettingPin));
+						expect(service.state.matches(AuthStateId.ResettingPin));
 						expect(service.state.context.error).toBe("PIN_RESET_FAILURE" as AuthError);
 					},
 				},
 			},
 			incorrectCurrentPin: {
 				on: {
-					PIN_SUBMITTED_WAS_CORRECT_ON_SECOND_ATTEMPT: "authenticated",
+					PIN_SUBMITTED_WAS_CORRECT_ON_SECOND_ATTEMPT: "Authenticated",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingCurrentPinInput));
+						expect(service.state.matches(AuthStateId.SubmittingCurrentPin));
 						expect(service.state.context.error).toBe("PIN_INVALID" as AuthError);
 					},
 				},
 			},
 			setANewPin: {
 				on: {
-					NEW_PIN_IS_FINE: "authenticated",
+					NEW_PIN_IS_FINE: "Authenticated",
 					NEW_PIN_IS_NOT_FINE: "errorSettingNewPin",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingNewPinInput));
+						expect(service.state.matches(AuthStateId.SubmittingNewPin));
 					},
 				},
 			},
 			errorSettingNewPin: {
 				on: {
-					NEW_PIN_IS_FINE_ON_SECOND_ATTEMPT: "authenticated",
+					NEW_PIN_IS_FINE_ON_SECOND_ATTEMPT: "Authenticated",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingCurrentPinInput));
+						expect(service.state.matches(AuthStateId.SubmittingCurrentPin));
 						expect(service.state.context.error).toBe("NEW_PIN_INVALID" as AuthError);
 					},
 				},
 			},
 			changeCurrentPin: {
 				on: {
-					PIN_CHANGE_SUCCEEDED: "authenticated",
+					PIN_CHANGE_SUCCEEDED: "Authenticated",
 					PIN_CHANGE_FAILED: "errorChangingCurrentPin",
-					ACTUALLY_CANCEL_THAT_PIN_CHANGE_REQUEST: "authenticated",
+					ACTUALLY_CANCEL_THAT_PIN_CHANGE_REQUEST: "Authenticated",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingChangePinInput));
+						expect(service.state.matches(AuthStateId.ChangingPin));
 					},
 				},
 			},
 			errorChangingCurrentPin: {
 				on: {
-					PIN_CHANGE_SUCCEEDED_ON_SECOND_ATTEMPT: "authenticated",
+					PIN_CHANGE_SUCCEEDED_ON_SECOND_ATTEMPT: "Authenticated",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.awaitingChangePinInput));
+						expect(service.state.matches(AuthStateId.ChangingPin));
 						expect(service.state.context.error).toBe("PIN_CHANGE_FAILURE" as AuthError);
 					},
 				},
 			},
-			authenticated: {
+			Authenticated: {
 				on: {
 					CHANGE_CURRENT_PIN_PLEASE: "changeCurrentPin",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {
-						expect(service.state.matches(AuthStateId.authenticated));
+						expect(service.state.matches(AuthStateId.Authenticated));
 					},
 				},
 			},

--- a/packages/authentication/src/auth-system.test.ts
+++ b/packages/authentication/src/auth-system.test.ts
@@ -528,6 +528,18 @@ describe("authentication test system for PIN (ignoring login flow)", () => {
 					},
 				},
 			},
+			validatePin: {
+				on: {
+					PIN_SUBMITTED_WAS_CORRECT: "changeCurrentPin",
+					PIN_SUBMITTED_WAS_NOT_CORRECT: "incorrectCurrentPin",
+					ACTUALLY_CANCEL_THAT_PIN_CHANGE_REQUEST: "Authenticated",
+				},
+				meta: {
+					test: async (service: AuthInterpreter) => {
+						expect(service.state.matches(AuthStateId.ValidatingPin));
+					},
+				},
+			},
 			changeCurrentPin: {
 				on: {
 					PIN_CHANGE_SUCCEEDED: "Authenticated",
@@ -553,7 +565,7 @@ describe("authentication test system for PIN (ignoring login flow)", () => {
 			},
 			Authenticated: {
 				on: {
-					CHANGE_CURRENT_PIN_PLEASE: "changeCurrentPin",
+					CHANGE_CURRENT_PIN_PLEASE: "validatePin",
 				},
 				meta: {
 					test: async (service: AuthInterpreter) => {

--- a/packages/authentication/src/auth-system.ts
+++ b/packages/authentication/src/auth-system.ts
@@ -54,6 +54,7 @@ export enum AuthStateId {
 	SubmittingCurrentPin = "SubmittingCurrentPin",
 	ResettingPin = "ResettingPin",
 	SubmittingNewPin = "SubmittingNewPin",
+	ValidatingPin = "ValidatingPin",
 	ChangingPin = "ChangingPin",
 	LoggingOut = "LoggingOut",
 	Authenticated = "Authenticated",
@@ -146,6 +147,7 @@ type InternalAuthTypeState =
 	| { value: AuthStateId.SubmittingCurrentPin; context: InternalAuthContext & { username?: string } }
 	| { value: AuthStateId.ResettingPin; context: InternalAuthContext }
 	| { value: AuthStateId.SubmittingNewPin; context: InternalAuthContext & { username?: string } }
+  | { value: AuthStateId.ValidatingPin; context: InternalAuthContext & { username?: string } }
 	| { value: AuthStateId.ChangingPin; context: InternalAuthContext & { username?: string } }
 	| { value: AuthStateId.LoggingOut; context: InternalAuthContext & { username?: string; } }
 	| { value: AuthStateId.Authenticated; context: InternalAuthContext & { username?: string; } };
@@ -401,16 +403,20 @@ export const machine = createMachine<
 				},
 			}	
 		},
-		[AuthStateId.ChangingPin]: {
+    [AuthStateId.ValidatingPin]: {
 			on: {
-        PIN_VALID: {
-					target: undefined,
+				PIN_VALID: {
+					target: AuthStateId.ChangingPin,
 					actions: ["clearError"],
 				},
 				PIN_INVALID: {
 					target: undefined,
 					actions: ["assignError"]
-				},
+				}
+			}
+		},
+		[AuthStateId.ChangingPin]: {
+			on: {
 				PIN_CHANGE_SUCCESS: {
 					target:AuthStateId.Authenticated,
 					actions: ["clearError"],
@@ -439,7 +445,7 @@ export const machine = createMachine<
 			entry: ["clearError"],
 			on: {
 				REQUEST_LOG_OUT: AuthStateId.LoggingOut,
-				REQUEST_PIN_CHANGE: AuthStateId.ChangingPin,
+				REQUEST_PIN_CHANGE: AuthStateId.ValidatingPin,
 				REQUEST_PASSWORD_CHANGE: AuthStateId.ChangingPassword,
 			}
 		},

--- a/packages/authentication/src/auth-system.ts
+++ b/packages/authentication/src/auth-system.ts
@@ -40,23 +40,23 @@ import type { AuthConfig, AuthError, DeviceSecurityType, LoginFlowType } from ".
  * The available states of the auth system FSM
  */
 export enum AuthStateId {
-	awaitingSessionCheck = "awaitingSessionCheck",
+	CheckingForSession = "CheckingForSession",
 	INTERNAL__loginFlowCheck = "INTERNAL__loginFlowCheck",
-	awaitingOtpUsername = "awaitingOtpUsername",
-	awaitingOtp = "awaitingOtp",
-	awaitingUsernameAndPassword = "awaitingUsernameAndPassword",
-	awaitingForcedChangePassword = "awaitingForcedChangePassword",
-	awaitingChangePassword = "awaitingChangePassword",
-	awaitingPasswordResetRequest = "awaitingPasswordResetRequest",
-	awaitingPasswordResetSubmission = "awaitingPasswordResetSubmission",
+	SubmittingOtpUsername = "SubmittingOtpUsername",
+	SubmittingOtp = "SubmittingOtp",
+	SubmittingUsernameAndPassword = "SubmittingUsernameAndPassword",
+	SubmittingForceChangePassword = "SubmittingForceChangePassword",
+	ChangingPassword = "ChangingPassword",
+	RequestingPasswordReset = "RequestingPasswordReset",
+	SubmittingPasswordReset = "SubmittingPasswordReset",
 	INTERNAL__deviceSecurityCheck = "INTERNAL__deviceSecurityCheck",
-	pinChecks = "pinChecks",
-	awaitingCurrentPinInput = "awaitingCurrentPinInput",
-	resettingPin = "resettingPin",
-	awaitingNewPinInput = "awaitingNewPinInput",
-	awaitingChangePinInput = "awaitingChangePinInput",
-	loggingOut = "loggingOut",
-	authenticated = "authenticated",
+	CheckingForPin = "CheckingForPin",
+	SubmittingCurrentPin = "SubmittingCurrentPin",
+	ResettingPin = "ResettingPin",
+	SubmittingNewPin = "SubmittingNewPin",
+	ChangingPin = "ChangingPin",
+	LoggingOut = "LoggingOut",
+	Authenticated = "Authenticated",
 }
 
 /**
@@ -134,21 +134,21 @@ type InternalAuthEvent =
  */
 // prettier-ignore
 type InternalAuthTypeState =
-	| { value: AuthStateId.awaitingSessionCheck; context: InternalAuthContext }
-	| { value: AuthStateId.awaitingOtpUsername; context: InternalAuthContext }
-	| { value: AuthStateId.awaitingOtp; context: InternalAuthContext & { user: any; username: string } }
-	| { value: AuthStateId.awaitingUsernameAndPassword; context: InternalAuthContext }
-	| {	value: AuthStateId.awaitingForcedChangePassword; context: InternalAuthContext & { user: any; username: string; error: AuthError } }
-	| { value: AuthStateId.awaitingChangePassword; context: InternalAuthContext & { username: string } }
-	| { value: AuthStateId.awaitingPasswordResetRequest; context: InternalAuthContext }
-	| { value: AuthStateId.awaitingPasswordResetSubmission; context: InternalAuthContext & { username: string } }
-	| { value: AuthStateId.pinChecks; context: InternalAuthContext & { username?: string } }
-	| { value: AuthStateId.awaitingCurrentPinInput; context: InternalAuthContext & { username?: string } }
-	| { value: AuthStateId.resettingPin; context: InternalAuthContext }
-	| { value: AuthStateId.awaitingNewPinInput; context: InternalAuthContext & { username?: string } }
-	| { value: AuthStateId.awaitingChangePinInput; context: InternalAuthContext & { username?: string } }
-	| { value: AuthStateId.loggingOut; context: InternalAuthContext & { username?: string; } }
-	| { value: AuthStateId.authenticated; context: InternalAuthContext & { username?: string; } };
+	| { value: AuthStateId.CheckingForSession; context: InternalAuthContext }
+	| { value: AuthStateId.SubmittingOtpUsername; context: InternalAuthContext }
+	| { value: AuthStateId.SubmittingOtp; context: InternalAuthContext & { user: any; username: string } }
+	| { value: AuthStateId.SubmittingUsernameAndPassword; context: InternalAuthContext }
+	| {	value: AuthStateId.SubmittingForceChangePassword; context: InternalAuthContext & { user: any; username: string; error: AuthError } }
+	| { value: AuthStateId.ChangingPassword; context: InternalAuthContext & { username: string } }
+	| { value: AuthStateId.RequestingPasswordReset; context: InternalAuthContext }
+	| { value: AuthStateId.SubmittingPasswordReset; context: InternalAuthContext & { username: string } }
+	| { value: AuthStateId.CheckingForPin; context: InternalAuthContext & { username?: string } }
+	| { value: AuthStateId.SubmittingCurrentPin; context: InternalAuthContext & { username?: string } }
+	| { value: AuthStateId.ResettingPin; context: InternalAuthContext }
+	| { value: AuthStateId.SubmittingNewPin; context: InternalAuthContext & { username?: string } }
+	| { value: AuthStateId.ChangingPin; context: InternalAuthContext & { username?: string } }
+	| { value: AuthStateId.LoggingOut; context: InternalAuthContext & { username?: string; } }
+	| { value: AuthStateId.Authenticated; context: InternalAuthContext & { username?: string; } };
 
 /* ------------------------------------------------------------------------------------------------------ *\
  * SYSTEM MODEL/FSM
@@ -220,11 +220,11 @@ export const machine = createMachine<
 >(
 	{
 		id: "authSystem",
-		initial: AuthStateId.awaitingSessionCheck,
+		initial: AuthStateId.CheckingForSession,
 		context: model.initialContext,
 		// prettier-ignore
 		states: {
-		[AuthStateId.awaitingSessionCheck]: {
+		[AuthStateId.CheckingForSession]: {
 			on: {
 				SESSION_PRESENT: AuthStateId.INTERNAL__deviceSecurityCheck,
 				SESSION_NOT_PRESENT: AuthStateId.INTERNAL__loginFlowCheck,
@@ -233,14 +233,14 @@ export const machine = createMachine<
 		[AuthStateId.INTERNAL__loginFlowCheck]: {
 			entry: ["clearError"],
 			always: [
-				{ cond: "isOtpLoginFlow", target: AuthStateId.awaitingOtpUsername },
-				{ cond: "isUsernamePasswordLoginFlow", target: AuthStateId.awaitingUsernameAndPassword },
+				{ cond: "isOtpLoginFlow", target: AuthStateId.SubmittingOtpUsername },
+				{ cond: "isUsernamePasswordLoginFlow", target: AuthStateId.SubmittingUsernameAndPassword },
 			],
 		},
-		[AuthStateId.awaitingOtpUsername]: {
+		[AuthStateId.SubmittingOtpUsername]: {
 			on: {
 				USERNAME_VALID: {
-					target: AuthStateId.awaitingOtp,
+					target: AuthStateId.SubmittingOtp,
 					actions: ["assignUser", "assignUsername", "clearError"],
 				},
 				USERNAME_INVALID: {
@@ -249,28 +249,28 @@ export const machine = createMachine<
 				}
 			},
 		},
-		[AuthStateId.awaitingOtp]: {
+		[AuthStateId.SubmittingOtp]: {
 			on: {
 				OTP_VALID: {
 					target: AuthStateId.INTERNAL__deviceSecurityCheck,
 					actions: ["clearError"],
 				},
 				OTP_INVALID: {
-					target: AuthStateId.awaitingOtp,
+					target: AuthStateId.SubmittingOtp,
 					actions: ["assignError"]
 				},
 				OTP_INVALID_RETRIES_EXCEEDED: {
-					target: AuthStateId.awaitingOtpUsername,
+					target: AuthStateId.SubmittingOtpUsername,
 					actions: ["assignError"]
 				},
 				GO_BACK: {
-					target: AuthStateId.awaitingOtpUsername,
+					target: AuthStateId.SubmittingOtpUsername,
 					// Going to start again, so don't want these hanging around:
 					actions: ["clearError", "clearUser", "clearUsername"],
 				}
 			},
 		},
-		[AuthStateId.awaitingUsernameAndPassword]: {
+		[AuthStateId.SubmittingUsernameAndPassword]: {
 			on: {
 				USERNAME_AND_PASSWORD_VALID: {
 					target: AuthStateId.INTERNAL__deviceSecurityCheck,
@@ -279,7 +279,7 @@ export const machine = createMachine<
 					actions: ["clearError"],
 				},
 				USERNAME_AND_PASSWORD_VALID_PASSWORD_CHANGE_REQUIRED: {
-					target: AuthStateId.awaitingForcedChangePassword,
+					target: AuthStateId.SubmittingForceChangePassword,
 					actions: ["assignError", "assignUser", "assignUsername"],
 				},
 				USERNAME_AND_PASSWORD_INVALID: {
@@ -287,12 +287,12 @@ export const machine = createMachine<
 					actions: ["assignError"]
 				},
 				FORGOTTEN_PASSWORD: {
-					target: AuthStateId.awaitingPasswordResetRequest,
+					target: AuthStateId.RequestingPasswordReset,
 					actions: ["clearError"],
 				},
 			}
 		},
-		[AuthStateId.awaitingForcedChangePassword]: {
+		[AuthStateId.SubmittingForceChangePassword]: {
 			on: {
 				PASSWORD_CHANGE_SUCCESS: {
 					target: AuthStateId.INTERNAL__deviceSecurityCheck,
@@ -304,19 +304,19 @@ export const machine = createMachine<
 				},
 			}
 		},
-		[AuthStateId.awaitingPasswordResetRequest]: {
+		[AuthStateId.RequestingPasswordReset]: {
 			on: {
 				PASSWORD_RESET_REQUEST_SUCCESS: {
-					target: AuthStateId.awaitingPasswordResetSubmission,
+					target: AuthStateId.SubmittingPasswordReset,
 					actions: ["clearError", "assignUsername"],
 				},
 				PASSWORD_RESET_REQUEST_FAILURE: {
-					target: AuthStateId.awaitingUsernameAndPassword,
+					target: AuthStateId.SubmittingUsernameAndPassword,
 					actions: ["assignError"]
 				},
 			}
 		},
-		[AuthStateId.awaitingPasswordResetSubmission]: {
+		[AuthStateId.SubmittingPasswordReset]: {
 			on: {
 				PASSWORD_RESET_SUCCESS: {
 					target: AuthStateId.INTERNAL__deviceSecurityCheck,
@@ -329,10 +329,10 @@ export const machine = createMachine<
 				},
 			}
 		},
-		[AuthStateId.awaitingChangePassword]: {
+		[AuthStateId.ChangingPassword]: {
 			on: {
 				PASSWORD_CHANGE_SUCCESS: {
-					target: AuthStateId.authenticated,
+					target: AuthStateId.Authenticated,
 					actions: ["clearError"],
 				},
 				// TODO will get stuck here, need to figure out how best to handle this:
@@ -340,27 +340,27 @@ export const machine = createMachine<
 					target: undefined,
 					actions: ["assignError"]
 				},
-				CANCEL_PASSWORD_CHANGE: AuthStateId.authenticated,
+				CANCEL_PASSWORD_CHANGE: AuthStateId.Authenticated,
 			}
 		},
 		[AuthStateId.INTERNAL__deviceSecurityCheck]: {
 			entry: ["clearError"],
 			always: [
-				{ cond: "isDeviceSecurityTypeNone", target: AuthStateId.authenticated },
-				{ cond: "isDeviceSecurityTypePin", target: AuthStateId.pinChecks },
-				// { cond: "isDeviceSecurityTypeBiometric", target: AuthStateId.authenticated },
+				{ cond: "isDeviceSecurityTypeNone", target: AuthStateId.Authenticated },
+				{ cond: "isDeviceSecurityTypePin", target: AuthStateId.CheckingForPin },
+				// { cond: "isDeviceSecurityTypeBiometric", target: AuthStateId.Authenticated },
 			],	
 		},
-		[AuthStateId.pinChecks]: {
+		[AuthStateId.CheckingForPin]: {
 			on: {
-				PIN_IS_SET_UP: AuthStateId.awaitingCurrentPinInput,
-				PIN_IS_NOT_SET_UP: AuthStateId.awaitingNewPinInput,
+				PIN_IS_SET_UP: AuthStateId.SubmittingCurrentPin,
+				PIN_IS_NOT_SET_UP: AuthStateId.SubmittingNewPin,
 			}
 		},
-		[AuthStateId.awaitingCurrentPinInput]: {
+		[AuthStateId.SubmittingCurrentPin]: {
 			on: {
 				PIN_VALID: {
-					target: AuthStateId.authenticated,
+					target: AuthStateId.Authenticated,
 					actions: ["clearError"],
 				},
 				PIN_INVALID: {
@@ -368,15 +368,15 @@ export const machine = createMachine<
 					actions: ["assignError"]
 				},
 				REQUEST_PIN_RESET: {
-					target: AuthStateId.resettingPin,
+					target: AuthStateId.ResettingPin,
 					actions: ["clearError"]
 				}
 			}
 		},
-		[AuthStateId.resettingPin]: {
+		[AuthStateId.ResettingPin]: {
 			on: {
 				PIN_RESET_SUCCESS: {
-					target: AuthStateId.awaitingSessionCheck,
+					target: AuthStateId.CheckingForSession,
 					actions: ["clearError"],
 				},
 				PIN_RESET_FAILURE: {
@@ -384,15 +384,15 @@ export const machine = createMachine<
 					actions: ["assignError"],
 				},
 				CANCEL_PIN_RESET: {
-					target: AuthStateId.awaitingCurrentPinInput,
+					target: AuthStateId.SubmittingCurrentPin,
 					actions: ["clearError"],
 				},
 			}
 		},
-		[AuthStateId.awaitingNewPinInput]: {
+		[AuthStateId.SubmittingNewPin]: {
 			on: {
 				NEW_PIN_VALID: {
-					target: AuthStateId.authenticated,
+					target: AuthStateId.Authenticated,
 					actions: ["clearError"],
 				},
 				NEW_PIN_INVALID: {
@@ -401,10 +401,10 @@ export const machine = createMachine<
 				},
 			}	
 		},
-		[AuthStateId.awaitingChangePinInput]: {
+		[AuthStateId.ChangingPin]: {
 			on: {
 				PIN_CHANGE_SUCCESS: {
-					target:AuthStateId.authenticated,
+					target:AuthStateId.Authenticated,
 					actions: ["clearError"],
 				},
 				PIN_CHANGE_FAILURE: {
@@ -412,27 +412,27 @@ export const machine = createMachine<
 					actions: ["assignError"]
 				},
 				CANCEL_PIN_CHANGE: {
-					target: AuthStateId.authenticated,
+					target: AuthStateId.Authenticated,
 					actions: ["clearError"]
 				}
 			}
 		},
-		[AuthStateId.loggingOut]: {
+		[AuthStateId.LoggingOut]: {
 			on: {
-				LOG_OUT_SUCCESS: AuthStateId.awaitingSessionCheck,
+				LOG_OUT_SUCCESS: AuthStateId.CheckingForSession,
 				LOG_OUT_FAILURE: {
 					target: undefined,
 					actions: ["assignError"]
 				},
-				CANCEL_LOG_OUT: AuthStateId.authenticated
+				CANCEL_LOG_OUT: AuthStateId.Authenticated
 			}
 		},
-		[AuthStateId.authenticated]: {
+		[AuthStateId.Authenticated]: {
 			entry: ["clearError"],
 			on: {
-				REQUEST_LOG_OUT: AuthStateId.loggingOut,
-				REQUEST_PIN_CHANGE: AuthStateId.awaitingChangePinInput,
-				REQUEST_PASSWORD_CHANGE: AuthStateId.awaitingChangePassword,
+				REQUEST_LOG_OUT: AuthStateId.LoggingOut,
+				REQUEST_PIN_CHANGE: AuthStateId.ChangingPin,
+				REQUEST_PASSWORD_CHANGE: AuthStateId.ChangingPassword,
 			}
 		},
 	},

--- a/packages/authentication/src/auth-system.ts
+++ b/packages/authentication/src/auth-system.ts
@@ -403,6 +403,14 @@ export const machine = createMachine<
 		},
 		[AuthStateId.ChangingPin]: {
 			on: {
+        PIN_VALID: {
+					target: undefined,
+					actions: ["clearError"],
+				},
+				PIN_INVALID: {
+					target: undefined,
+					actions: ["assignError"]
+				},
 				PIN_CHANGE_SUCCESS: {
 					target:AuthStateId.Authenticated,
 					actions: ["clearError"],

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -36,6 +36,8 @@ export const AuthStage = {
 	useSubmittingUsernameAndPassword,
 };
 
+export { useAuthenticated, useChangingPassword, useChangingPin, useLoggingOut };
+
 export { AuthProvider } from "./AuthSystemProvider";
 export { createAuthenticationSystem } from "./auth-system";
 

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -1,4 +1,42 @@
-export * as AuthStage from "./auth-system-hooks";
+import {
+	useAuthenticated,
+	useAwaitingChangePassword,
+	useAwaitingChangePinInput,
+	useAwaitingCurrentPinInput,
+	useAwaitingForcedChangePassword,
+	useAwaitingNewPinInput,
+	useAwaitingOtp,
+	useAwaitingOtpUsername,
+	useAwaitingPasswordResetRequest,
+	useAwaitingPasswordResetSubmission,
+	useAwaitingSessionCheck,
+	useAwaitingUsernameAndPassword,
+	useLoggingOut,
+	usePinChecks,
+	useResettingPin,
+} from "./auth-system-hooks";
+
+export const AuthStage = {
+	useAwaitingCurrentPinInput,
+	useAwaitingForcedChangePassword,
+	useAwaitingNewPinInput,
+	useAwaitingOtp,
+	useAwaitingOtpUsername,
+	useAwaitingPasswordResetRequest,
+	useAwaitingPasswordResetSubmission,
+	useAwaitingSessionCheck,
+	useAwaitingUsernameAndPassword,
+	usePinChecks,
+	useResettingPin,
+};
+
+export const Auth = {
+	useAuthenticated,
+	useAwaitingChangePassword,
+	useAwaitingChangePinInput,
+	useLoggingOut,
+};
+
 export { AuthProvider } from "./AuthSystemProvider";
 export { createAuthenticationSystem } from "./auth-system";
 

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -1,41 +1,36 @@
 import {
 	useAuthenticated,
-	useAwaitingChangePassword,
-	useAwaitingChangePinInput,
-	useAwaitingCurrentPinInput,
-	useAwaitingForcedChangePassword,
-	useAwaitingNewPinInput,
-	useAwaitingOtp,
-	useAwaitingOtpUsername,
-	useAwaitingPasswordResetRequest,
-	useAwaitingPasswordResetSubmission,
-	useAwaitingSessionCheck,
-	useAwaitingUsernameAndPassword,
+	useChangingPassword,
+	useChangingPin,
+	useCheckingForPin,
+	useCheckingForSession,
 	useLoggingOut,
-	usePinChecks,
+	useRequestingPasswordReset,
 	useResettingPin,
+	useSubmittingCurrentPin,
+	useSubmittingForceChangePassword,
+	useSubmittingNewPin,
+	useSubmittingOtp,
+	useSubmittingOtpUsername,
+	useSubmittingPasswordReset,
+	useSubmittingUsernameAndPassword,
 } from "./auth-system-hooks";
 
 export const AuthStage = {
-	useAwaitingCurrentPinInput,
-	useAwaitingForcedChangePassword,
-	useAwaitingNewPinInput,
-	useAwaitingOtp,
-	useAwaitingOtpUsername,
-	useAwaitingPasswordResetRequest,
-	useAwaitingPasswordResetSubmission,
-	useAwaitingSessionCheck,
-	useAwaitingUsernameAndPassword,
-	usePinChecks,
+	useSubmittingCurrentPin,
+	useSubmittingForceChangePassword,
+	useSubmittingNewPin,
+	useSubmittingOtp,
+	useSubmittingOtpUsername,
+	useRequestingPasswordReset,
+	useSubmittingPasswordReset,
+	useCheckingForSession,
+	useSubmittingUsernameAndPassword,
+	useCheckingForPin,
 	useResettingPin,
 };
 
-export const Auth = {
-	useAuthenticated,
-	useAwaitingChangePassword,
-	useAwaitingChangePinInput,
-	useLoggingOut,
-};
+export { useAuthenticated, useChangingPassword, useChangingPin, useLoggingOut };
 
 export { AuthProvider } from "./AuthSystemProvider";
 export { createAuthenticationSystem } from "./auth-system";

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -14,23 +14,27 @@ import {
 	useSubmittingOtpUsername,
 	useSubmittingPasswordReset,
 	useSubmittingUsernameAndPassword,
+	useValidatingPin,
 } from "./auth-system-hooks";
 
 export const AuthStage = {
+	useValidatingPin,
+	useAuthenticated,
+	useChangingPassword,
+	useChangingPin,
+	useCheckingForPin,
+	useCheckingForSession,
+	useLoggingOut,
+	useRequestingPasswordReset,
+	useResettingPin,
 	useSubmittingCurrentPin,
 	useSubmittingForceChangePassword,
 	useSubmittingNewPin,
 	useSubmittingOtp,
 	useSubmittingOtpUsername,
-	useRequestingPasswordReset,
 	useSubmittingPasswordReset,
-	useCheckingForSession,
 	useSubmittingUsernameAndPassword,
-	useCheckingForPin,
-	useResettingPin,
 };
-
-export { useAuthenticated, useChangingPassword, useChangingPin, useLoggingOut };
 
 export { AuthProvider } from "./AuthSystemProvider";
 export { createAuthenticationSystem } from "./auth-system";

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -36,7 +36,7 @@ export const AuthStage = {
 	useSubmittingUsernameAndPassword,
 };
 
-export { useAuthenticated, useChangingPassword, useChangingPin, useLoggingOut };
+export { useAuthenticated, useChangingPassword, useChangingPin, useLoggingOut, useValidatingPin };
 
 export { AuthProvider } from "./AuthSystemProvider";
 export { createAuthenticationSystem } from "./auth-system";

--- a/packages/authentication/src/test-app/App.tsx
+++ b/packages/authentication/src/test-app/App.tsx
@@ -14,7 +14,7 @@ export const App = () => (
 			<header className="app-section__header">
 				<h2>Auth flow</h2>
 			</header>
-			<AuthStage.SessionCheck />
+			<AuthStage.CheckingForSession />
 			<AuthStage.OtpUsernameInput />
 			<AuthStage.OtpInput />
 			<AuthStage.Authenticated />

--- a/packages/authentication/src/test-app/App.tsx
+++ b/packages/authentication/src/test-app/App.tsx
@@ -22,6 +22,7 @@ export const App = () => (
 			<AuthStage.CheckPin />
 			<AuthStage.CurrentPinInput />
 			<AuthStage.NewPinInput />
+			<AuthStage.ValidatePinInput />
 			<AuthStage.ChangePinInput />
 		</article>
 	</AuthProvider>

--- a/packages/authentication/src/test-app/AuthStages.tsx
+++ b/packages/authentication/src/test-app/AuthStages.tsx
@@ -5,8 +5,8 @@ import React from "react";
 import { AuthStage } from "..";
 import { Form } from "./Components";
 
-export const SessionCheck = () => {
-	const { isActive, isLoading, checkSession, error } = AuthStage.useAwaitingSessionCheck(() =>
+export const CheckingForSession = () => {
+	const { isActive, isLoading, checkSession, error } = AuthStage.useCheckingForSession(() =>
 		Auth.currentSession()
 	);
 
@@ -15,7 +15,7 @@ export const SessionCheck = () => {
 			<Form submitCb={checkSession}>
 				<Form.Elements disabled={!isActive || isLoading} error={error}>
 					<Form.Controls>
-						<Form.Submit label="Check Session" testid="sessionCheckSubmit" />
+						<Form.Submit label="Check Session" testid="CheckingForSessionSubmit" />
 					</Form.Controls>
 				</Form.Elements>
 			</Form>
@@ -24,7 +24,7 @@ export const SessionCheck = () => {
 };
 
 export const OtpUsernameInput = () => {
-	const { error, isActive, isLoading, validateUsername } = AuthStage.useAwaitingOtpUsername(
+	const { error, isActive, isLoading, validateUsername } = AuthStage.useSubmittingOtpUsername(
 		(username: string) => Auth.signIn(username)
 	);
 	const [username, setUsername] = React.useState("");
@@ -53,7 +53,7 @@ export const OtpUsernameInput = () => {
 };
 
 export const OtpInput = () => {
-	const { error, isActive, isLoading, validateOtp } = AuthStage.useAwaitingOtp(
+	const { error, isActive, isLoading, validateOtp } = AuthStage.useSubmittingOtp(
 		async (user, password) => {
 			await Auth.sendCustomChallengeAnswer(user, password);
 			return Auth.currentAuthenticatedUser();
@@ -122,7 +122,7 @@ const LocalPinService = {
 };
 
 export const CheckPin = () => {
-	const { error, isActive, isLoading, checkForExistingPin } = AuthStage.usePinChecks(() =>
+	const { error, isActive, isLoading, checkForExistingPin } = AuthStage.useCheckingForPin(() =>
 		LocalPinService.hasPinSet()
 	);
 
@@ -140,7 +140,7 @@ export const CheckPin = () => {
 };
 
 export const CurrentPinInput = () => {
-	const { error, isActive, isLoading, validatePin } = AuthStage.useAwaitingCurrentPinInput((pin) =>
+	const { error, isActive, isLoading, validatePin } = AuthStage.useSubmittingCurrentPin((pin) =>
 		LocalPinService.checkPin(pin)
 	);
 	const [pin, setPin] = React.useState("");
@@ -169,7 +169,7 @@ export const CurrentPinInput = () => {
 };
 
 export const NewPinInput = () => {
-	const { error, isActive, isLoading, setNewPin } = AuthStage.useAwaitingNewPinInput((pin) =>
+	const { error, isActive, isLoading, setNewPin } = AuthStage.useSubmittingNewPin((pin) =>
 		LocalPinService.setPin(pin)
 	);
 	const [pin, setPin] = React.useState("");
@@ -198,10 +198,9 @@ export const NewPinInput = () => {
 };
 
 export const ChangePinInput = () => {
-	const { error, isActive, isLoading, changePin, cancelChangePin } =
-		AuthStage.useAwaitingChangePinInput((oldPin, newPin) =>
-			LocalPinService.changePin(oldPin, newPin)
-		);
+	const { error, isActive, isLoading, changePin, cancelChangePin } = AuthStage.useChangingPin(
+		(oldPin, newPin) => LocalPinService.changePin(oldPin, newPin)
+	);
 	const [oldPin, setOldPin] = React.useState("");
 	const [newPin, setNewPin] = React.useState("");
 
@@ -251,14 +250,14 @@ export const Authenticated = () => {
 			<Form submitCb={requestLogOut}>
 				<Form.Elements disabled={!isActive}>
 					<Form.Controls>
-						<Form.Submit label="I want to log out!" testid="authenticatedLogOutSubmit" />
+						<Form.Submit label="I want to log out!" testid="AuthenticatedLogOutSubmit" />
 					</Form.Controls>
 				</Form.Elements>
 			</Form>
 			<Form submitCb={requestPinChange}>
 				<Form.Elements disabled={!isActive}>
 					<Form.Controls>
-						<Form.Submit label="I want to change my PIN!" testid="authenticatedPinChangeSubmit" />
+						<Form.Submit label="I want to change my PIN!" testid="AuthenticatedPinChangeSubmit" />
 					</Form.Controls>
 				</Form.Elements>
 			</Form>
@@ -279,9 +278,9 @@ export const LoggingOut = () => {
 						<Form.SecondaryAction
 							label="Cancel logout!"
 							actionCallback={cancelLogOut}
-							testid="loggingOutCancel"
+							testid="LoggingOutCancel"
 						/>
-						<Form.Submit label="I really do want to log out!" testid="loggingOutSubmit" />
+						<Form.Submit label="I really do want to log out!" testid="LoggingOutSubmit" />
 					</Form.Controls>
 				</Form.Elements>
 			</Form>

--- a/packages/authentication/src/test-app/AuthStages.tsx
+++ b/packages/authentication/src/test-app/AuthStages.tsx
@@ -211,7 +211,7 @@ export const ValidatePinInput = () => {
 						id="currentPin"
 						inputType="text"
 						isActive={isActive}
-						label="Enter your current pin:"
+						label="Confirm your current pin:"
 						value={pin}
 						valueSetter={setPin}
 						testid="currentPinInput"
@@ -229,23 +229,12 @@ export const ChangePinInput = () => {
 	const { error, isActive, isLoading, changePin, cancelChangePin } = AuthStage.useChangingPin(
 		(newPin) => LocalPinService.changePin(newPin)
 	);
-	const [oldPin, setOldPin] = React.useState("");
 	const [newPin, setNewPin] = React.useState("");
 
 	return (
 		<section className={classnames("auth-stage", { "auth-stage--active": isActive })}>
-			<Form submitCb={changePin} cbParams={[oldPin, newPin]}>
+			<Form submitCb={changePin} cbParams={[newPin]}>
 				<Form.Elements disabled={!isActive || isLoading} error={error}>
-					<Form.InputGroup
-						error={error}
-						id="oldPinToChange"
-						inputType="text"
-						isActive={isActive}
-						label="Enter your current PIN:"
-						value={oldPin}
-						valueSetter={setOldPin}
-						testid="oldPinInput"
-					/>
 					<Form.InputGroup
 						error={error}
 						id="newPinToSet"

--- a/packages/authentication/src/test-app/AuthStages.tsx
+++ b/packages/authentication/src/test-app/AuthStages.tsx
@@ -103,11 +103,10 @@ const LocalPinService = {
 			return Promise.reject();
 		}
 	},
-	async changePin(oldPin: string, newPin: string) {
-		const storedPin = window.localStorage.getItem(PIN_KEY);
-		if (storedPin === oldPin) {
+	async changePin(newPin: string) {
+		try {
 			return await LocalPinService.setPin(newPin);
-		} else {
+		} catch {
 			return Promise.reject();
 		}
 	},
@@ -197,9 +196,38 @@ export const NewPinInput = () => {
 	);
 };
 
+export const ValidatePinInput = () => {
+	const { error, isActive, isLoading, validatePin } = AuthStage.useValidatingPin((pin) =>
+		LocalPinService.checkPin(pin)
+	);
+	const [pin, setPin] = React.useState("");
+
+	return (
+		<section className={classnames("auth-stage", { "auth-stage--active": isActive })}>
+			<Form submitCb={validatePin} cbParams={[pin]}>
+				<Form.Elements disabled={!isActive || isLoading} error={error}>
+					<Form.InputGroup
+						error={error}
+						id="currentPin"
+						inputType="text"
+						isActive={isActive}
+						label="Enter your current pin:"
+						value={pin}
+						valueSetter={setPin}
+						testid="currentPinInput"
+					/>
+					<Form.Controls>
+						<Form.Submit label="Submit PIN" testid="currentPinSubmit" />
+					</Form.Controls>
+				</Form.Elements>
+			</Form>
+		</section>
+	);
+};
+
 export const ChangePinInput = () => {
 	const { error, isActive, isLoading, changePin, cancelChangePin } = AuthStage.useChangingPin(
-		(oldPin, newPin) => LocalPinService.changePin(oldPin, newPin)
+		(newPin) => LocalPinService.changePin(newPin)
 	);
 	const [oldPin, setOldPin] = React.useState("");
 	const [newPin, setNewPin] = React.useState("");


### PR DESCRIPTION
Added a selector for states that are accessible while a user is authenticated.

Add a selector function `isInStateAccessibleWhileAuthenticated` (only for use internally, not exposed, hence the verbose name) that checks against a (typed) set of states for matches.

If one of the matches returns true, then can assume still authed. All of
these states shouldn't really move a user into an unauthorised state -- so for
example `useLoggingOut`: the program isn't actually unauthorised when in that
state, it is only after another action is sent.

This fixes the issue of losing the place in the navigation: prior to the
change, moving from profile screen to `loggingOut` state would have mean de-authorising.
Then if a user cancels, they go back to the dashboard instead of the profile page.

By keeping them authed, the `loggingOut` state can be described using a
modal/view in the profile section.

This also applies (currently) to the `changePasswordInput` and `changePinInput` states.